### PR TITLE
Don't raise in the base `Stream`'s readiness-checker

### DIFF
--- a/pyjelly/_serializing/streams.py
+++ b/pyjelly/_serializing/streams.py
@@ -56,7 +56,7 @@ class Stream:
             True if `add()` should return a frame, otherwise False.
 
         """
-        raise NotImplementedError
+        return False
 
     @cached_property
     def protobuf_type(self) -> pb.LogicalStreamType:


### PR DESCRIPTION
In practice, you should be able to reuse the base `Stream` class to manually control when to make frames.