### PR TITLE
Remove `pypy3.11` from CI matrix

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -46,8 +46,6 @@ jobs:
           platform: ubuntu-latest
         - version: pypy3.10
           platform: ubuntu-latest  
-        - version: pypy3.11
-          platform: ubuntu-latest
 
     env:
       uv-sync: uv sync --frozen --python ${{matrix.version}}


### PR DESCRIPTION
It's still new, most people use pypy 3.10 still. +Build fails, which renders all current PRs red.
We can wait until our dependency supply chain is ready for it