### PR TITLE
Make `grpcio-tools` optional in dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,9 @@ jelly = "pyjelly._rdflib.serializer:RDFLibJellySerializer"
 "application/x-jelly-rdf" = "pyjelly._rdflib.serializer:RDFLibJellySerializer"
 
 [dependency-groups]
-dev = ["grpcio-tools>=1.71.0", "mypy>=1.13.0", "ruff>=0.8.6"]
+dev = ["mypy>=1.13.0", "ruff>=0.8.6"]
 maintenance = ["towncrier>=24.8.0"]
+protoc = ["grpcio-tools>=1.71.0"]
 profiling = ["scalene>=1.5.51", "memray>=1.16.0"]
 test = [
     "inline-snapshot>=0.20.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 ]
 requires-python = ">=3.9"
 dependencies = [
+    "grpcio>=1.71.0",
     "protobuf>=5.29.3",
     "typer>=0.15.2",
     "typing-extensions>=4.12.2", # revisit after 3.13 is older

--- a/uv.lock
+++ b/uv.lock
@@ -827,7 +827,6 @@ rdflib = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "grpcio-tools" },
     { name = "mypy" },
     { name = "ruff" },
 ]
@@ -840,6 +839,9 @@ maintenance = [
 profiling = [
     { name = "memray" },
     { name = "scalene" },
+]
+protoc = [
+    { name = "grpcio-tools" },
 ]
 test = [
     { name = "inline-snapshot" },
@@ -864,7 +866,6 @@ provides-extras = ["rdflib"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "grpcio-tools", specifier = ">=1.71.0" },
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "ruff", specifier = ">=0.8.6" },
 ]
@@ -874,6 +875,7 @@ profiling = [
     { name = "memray", specifier = ">=1.16.0" },
     { name = "scalene", specifier = ">=1.5.51" },
 ]
+protoc = [{ name = "grpcio-tools", specifier = ">=1.71.0" }]
 test = [
     { name = "inline-snapshot", specifier = ">=0.20.8" },
     { name = "pytest", specifier = ">=8.3.4" },

--- a/uv.lock
+++ b/uv.lock
@@ -815,6 +815,7 @@ name = "pyjelly"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "grpcio" },
     { name = "protobuf" },
     { name = "typer" },
     { name = "typing-extensions" },
@@ -857,6 +858,7 @@ types = [
 
 [package.metadata]
 requires-dist = [
+    { name = "grpcio", specifier = ">=1.71.0" },
     { name = "protobuf", specifier = ">=5.29.3" },
     { name = "rdflib", marker = "extra == 'rdflib'", specifier = ">=7.1.4" },
     { name = "typer", specifier = ">=0.15.2" },


### PR DESCRIPTION
Avoids pypy3.11 CI build problems, adds a hard dep on what is actually needed at runtime.