### PR TITLE
Use flat logical type by default

### DIFF
--- a/pyjelly/__init__.py
+++ b/pyjelly/__init__.py
@@ -1,7 +1,8 @@
 from pyjelly.producing.encoder import Encoder
-from pyjelly.producing.producers import FlatProducer, Producer
+from pyjelly.producing.producers import BoundedFlatProducer, FlatProducer, Producer
 
 __all__ = (
+    "BoundedFlatProducer",
     "Encoder",
     "FlatProducer",
     "Producer",

--- a/pyjelly/_rdflib/serializer.py
+++ b/pyjelly/_rdflib/serializer.py
@@ -14,7 +14,7 @@ from pyjelly import jelly
 from pyjelly.options import StreamOptions
 from pyjelly.producing import stream_to_frame, stream_to_frames
 from pyjelly.producing.encoder import Encoder, TermName
-from pyjelly.producing.producers import Producer
+from pyjelly.producing.producers import FlatProducer, Producer
 
 
 def serialize_delimited(
@@ -25,7 +25,9 @@ def serialize_delimited(
     statements: Iterable[Iterable[Node]],
 ) -> None:
     for frame in stream_to_frames(
-        encoder=encoder, statements=statements, producer=producer
+        encoder=encoder,
+        statements=statements,
+        producer=producer,
     ):
         serialize_length_prefixed(frame, out)
 
@@ -101,7 +103,7 @@ class RDFLibJellySerializer(RDFLibSerializer):
         if encoder.options.delimited:
             serialize_delimited(
                 out,
-                producer=producer or Producer(),
+                producer=producer or FlatProducer(),
                 encoder=encoder,
                 statements=statements,
             )

--- a/pyjelly/producing/__init__.py
+++ b/pyjelly/producing/__init__.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable, Iterator
 
 from pyjelly import jelly
 from pyjelly.producing.encoder import Encoder
-from pyjelly.producing.producers import FlatProducer
+from pyjelly.producing.producers import Producer
 
 
 def stream_to_frame(
@@ -21,7 +21,7 @@ def stream_to_frame(
 
 
 def stream_to_frames(
-    producer: FlatProducer,
+    producer: Producer,
     encoder: Encoder,
     statements: Iterable[Iterable[object]],
 ) -> Iterator[jelly.RdfStreamFrame]:

--- a/pyjelly/producing/__init__.py
+++ b/pyjelly/producing/__init__.py
@@ -2,7 +2,7 @@ from collections.abc import Iterable, Iterator
 
 from pyjelly import jelly
 from pyjelly.producing.encoder import Encoder
-from pyjelly.producing.producers import Producer
+from pyjelly.producing.producers import FlatProducer
 
 
 def stream_to_frame(
@@ -21,7 +21,7 @@ def stream_to_frame(
 
 
 def stream_to_frames(
-    producer: Producer,
+    producer: FlatProducer,
     encoder: Encoder,
     statements: Iterable[Iterable[object]],
 ) -> Iterator[jelly.RdfStreamFrame]:


### PR DESCRIPTION
Closes #39 

To confirm:

```bash
$ python -m tests.serialize whatever.nt
$ jelly rdf inspect out.jelly | yq .stream_options.logical_type
LOGICAL_STREAM_TYPE_FLAT_TRIPLES (1)
```