### PR TITLE
Producing: Add support for quad physical type

### DIFF
--- a/pyjelly/integrations/rdflib/serializer.py
+++ b/pyjelly/integrations/rdflib/serializer.py
@@ -16,6 +16,8 @@ from pyjelly.producing import stream_to_frame, stream_to_frames
 from pyjelly.producing.encoder import Encoder, TermName
 from pyjelly.producing.producers import FlatProducer, Producer
 
+DEFAULT_GRAPH_IRI = rdflib.URIRef("urn:x-rdflib:default")
+
 
 def serialize_delimited(
     out: IO[bytes],
@@ -45,9 +47,9 @@ def serialize(
 class RDFLibEncoder(Encoder):
     @override
     def encode_term(self, term: Node, name: TermName) -> None:
-        if term is None and name == "g":
-            return
-        if isinstance(term, rdflib.URIRef):
+        if name == "g" and term == DEFAULT_GRAPH_IRI:
+            self.encode_default_graph(term_name=name)
+        elif isinstance(term, rdflib.URIRef):
             self.encode_iri(term, term_name=name)
         elif isinstance(term, rdflib.Literal):
             self.encode_literal(

--- a/pyjelly/integrations/rdflib/serializer.py
+++ b/pyjelly/integrations/rdflib/serializer.py
@@ -90,20 +90,21 @@ class RDFLibJellySerializer(RDFLibSerializer):
         **unused: Any,
     ) -> None:
         store = self.store
-        statements: Iterable[Iterable[Node]] = store
+        statements: Iterable[Iterable[Any]] = store
         if isinstance(store, rdflib.Dataset):
             if quads:
                 physical_type = jelly.PHYSICAL_STREAM_TYPE_QUADS
+                statements = store.quads()
             else:
                 physical_type = jelly.PHYSICAL_STREAM_TYPE_GRAPHS
-                statements = store.graphs()  # type: ignore[assignment]
+                statements = store.graphs()
         else:
             physical_type = jelly.PHYSICAL_STREAM_TYPE_TRIPLES
         encoder = RDFLibEncoder(physical_type=physical_type, options=options)
         if encoder.options.delimited:
             serialize_delimited(
                 out,
-                producer=producer or FlatProducer(),
+                producer=producer or FlatProducer(targets_quads=quads),
                 encoder=encoder,
                 statements=statements,
             )

--- a/pyjelly/producing/encoder.py
+++ b/pyjelly/producing/encoder.py
@@ -38,7 +38,7 @@ class Statement:
     def add_term(
         self,
         name: TermName,
-        value: jelly.RdfIri | str | jelly.RdfLiteral,
+        value: jelly.RdfIri | str | jelly.RdfLiteral | jelly.RdfDefaultGraph,
         rows: Iterable[jelly.RdfStreamRow] = (),
     ) -> None:
         self.extra_stream_rows[name] = rows

--- a/pyjelly/producing/encoder.py
+++ b/pyjelly/producing/encoder.py
@@ -32,13 +32,13 @@ class Statement:
         self.jelly_statement: Any = jelly.RdfQuad if quads else jelly.RdfTriple
         self.row_oneof: Any = STATEMENT_ONEOF_NAMES[self.jelly_statement]
         self.extra_stream_rows: dict[TermName, Iterable[jelly.RdfStreamRow]] = {}
-        self.term_values: dict[TermName, jelly.RdfIri | jelly.RdfLiteral | str] = {}
+        self.term_values: dict[TermName, object] = {}
         self.term_types: dict[TermName, str] = {}
 
     def add_term(
         self,
         name: TermName,
-        value: jelly.RdfIri | str | jelly.RdfLiteral | jelly.RdfDefaultGraph,
+        value: object,
         rows: Iterable[jelly.RdfStreamRow] = (),
     ) -> None:
         self.extra_stream_rows[name] = rows

--- a/pyjelly/producing/encoder.py
+++ b/pyjelly/producing/encoder.py
@@ -16,6 +16,7 @@ TERM_ONEOF_NAMES = {
     jelly.RdfIri: "iri",
     jelly.RdfLiteral: "literal",
     str: "bnode",
+    jelly.RdfDefaultGraph: "default_graph",
 }
 
 STATEMENT_ONEOF_NAMES = {
@@ -163,6 +164,9 @@ class Encoder(metaclass=ABCMeta):
         name_id = self.names.encode_name_term_index(name)
         jelly_iri = jelly.RdfIri(prefix_id=prefix_id, name_id=name_id)
         self.statement.add_term(term_name, jelly_iri, rows=term_rows)
+
+    def encode_default_graph(self, *, term_name: TermName) -> None:
+        self.statement.add_term(term_name, jelly.RdfDefaultGraph())
 
     def encode_bnode(self, bnode: str, *, term_name: TermName) -> None:
         self.statement.add_term(term_name, str(bnode))  # invariant str needed

--- a/tests/parse.py
+++ b/tests/parse.py
@@ -6,7 +6,6 @@ import argparse
 
 import rdflib
 
-from pyjelly.options import register_mimetypes
 from tests.utils.ordered_memory import OrderedMemory
 
 
@@ -17,7 +16,6 @@ def main(location: str, output: str) -> None:
 
 
 if __name__ == "__main__":
-    register_mimetypes()
     cli = argparse.ArgumentParser()
     cli.add_argument("location", nargs="?", default="out.jelly", type=str)
     cli.add_argument("output", nargs="?", default="out-parsed.jelly", type=str)

--- a/tests/serialize.py
+++ b/tests/serialize.py
@@ -7,11 +7,28 @@ from pathlib import Path
 
 import rdflib
 
-from pyjelly.options import register_mimetypes
 from tests.utils.ordered_memory import OrderedMemory
 
 
-def main(location: str, output: str | Path) -> None:
+def serialize_dataset(
+    locations: list[str],
+    output: str | Path,
+    *,
+    quads: bool = False,
+) -> None:
+    dataset = rdflib.Dataset()
+    for location in locations:
+        if quads:
+            dataset.parse(location=location)
+        else:
+            graph = rdflib.Graph(identifier=location, store=OrderedMemory())
+            graph.parse(location=location)
+            dataset.add_graph(graph)
+    with Path(output).open("wb") as file:
+        dataset.serialize(destination=file, quads=quads, format="jelly")
+
+
+def serialize_graph(location: str, output: str | Path) -> None:
     graph = rdflib.Graph(store=OrderedMemory())
     graph.parse(location=location)
     with Path(output).open("wb") as file:
@@ -19,9 +36,16 @@ def main(location: str, output: str | Path) -> None:
 
 
 if __name__ == "__main__":
-    register_mimetypes()
     cli = argparse.ArgumentParser()
-    cli.add_argument("location", type=str)
+    cli.add_argument("first", type=str)
+    cli.add_argument("extra", nargs="*", type=str)
     cli.add_argument("output", nargs="?", default="out.jelly", type=str)
     args = cli.parse_args()
-    main(location=args.location, output=args.output)
+    if not args.extra:
+        serialize_graph(args.first, output=args.output)
+    else:
+        serialize_dataset(
+            [args.first, *args.extra],
+            output=args.output,
+            quads=args.first.endswith(".nq"),
+        )

--- a/tests/serialize.py
+++ b/tests/serialize.py
@@ -41,11 +41,12 @@ if __name__ == "__main__":
     cli.add_argument("extra", nargs="*", type=str)
     cli.add_argument("output", nargs="?", default="out.jelly", type=str)
     args = cli.parse_args()
-    if not args.extra:
-        serialize_graph(args.first, output=args.output)
-    else:
+    quads = args.first.endswith(".nq")
+    if quads or args.extra:
         serialize_dataset(
             [args.first, *args.extra],
             output=args.output,
             quads=args.first.endswith(".nq"),
         )
+    else:
+        serialize_graph(args.first, output=args.output)


### PR DESCRIPTION
Closes #32

Tested against this quad file (`quads.nq`)

```nq
<http://example.org/alice> <http://xmlns.com/foaf/0.1/name> "Alice" <http://example.org/graph1> .
<http://example.org/alice> <http://xmlns.com/foaf/0.1/gender> "female" .
<http://example.org/bob> <http://xmlns.com/foaf/0.1/knows> _:b1 <http://example.org/graph1> .
_:b1 <http://xmlns.com/foaf/0.1/name> "Charlie" <http://example.org/graph2> .
<http://example.org/bob> <http://xmlns.com/foaf/0.1/age> "32"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/graph3> .
<http://example.org/bob> <http://xmlns.com/foaf/0.1/name> "Bob"@en <http://example.org/graph3> .
<http://example.org/book1> <http://purl.org/dc/elements/1.1/title> "Understanding RDF"@en <http://example.org/graph5> .
<http://example.org/book1> <http://purl.org/dc/elements/1.1/date> "2022-08-15"^^<http://www.w3.org/2001/XMLSchema#date> <http://example.org/graph5> .
```

Passed

```
jelly-cli rdf validate out.jelly --compare-to-rdf-file quads.nq
```

Produced same stats as Jelly-JVM

```bash
$ jelly-cli rdf inspect out.jelly 
stream_options: 
  stream_name: ""
  physical_type: PHYSICAL_STREAM_TYPE_QUADS (2)
  generalized_statements: true
  rdf_star: false
  max_name_table_size: 4000
  max_prefix_table_size: 150
  max_datatype_table_size: 32
  logical_type: LOGICAL_STREAM_TYPE_FLAT_QUADS (2)
  version: 1

frames: 
  frame_count: 1
  option_count: 1
  triple_count: 0
  quad_count: 8
  graph_start_count: 0
  graph_end_count: 0
  namespace_count: 0
  name_count: 13
  prefix_count: 3
  datatype_count: 2
```

This is mainly some glue to use what we already have :) And a rewrite of the testing CLI.