### PR TITLE
Rewrite serialization script

### DIFF
--- a/tests/serialize.py
+++ b/tests/serialize.py
@@ -10,28 +10,28 @@ import rdflib
 from tests.utils.ordered_memory import OrderedMemory
 
 
-def serialize_dataset(
-    locations: list[str],
-    output: str | Path,
+def write_dataset(
+    filenames: list[str],
+    output_filename: str | Path,
     *,
     quads: bool = False,
 ) -> None:
     dataset = rdflib.Dataset()
-    for location in locations:
-        if quads:
-            dataset.parse(location=location)
+    for filename in filenames:
+        if filename.endswith(".nq"):
+            dataset.parse(location=filename)
         else:
-            graph = rdflib.Graph(identifier=location, store=OrderedMemory())
-            graph.parse(location=location)
+            graph = rdflib.Graph(identifier=filename, store=OrderedMemory())
+            graph.parse(location=filename)
             dataset.add_graph(graph)
-    with Path(output).open("wb") as file:
+    with Path(output_filename).open("wb") as file:
         dataset.serialize(destination=file, quads=quads, format="jelly")
 
 
-def serialize_graph(location: str, output: str | Path) -> None:
+def write_graph(filename: str, output_filename: str | Path) -> None:
     graph = rdflib.Graph(store=OrderedMemory())
-    graph.parse(location=location)
-    with Path(output).open("wb") as file:
+    graph.parse(location=filename)
+    with Path(output_filename).open("wb") as file:
         graph.serialize(destination=file, format="jelly")
 
 
@@ -40,13 +40,14 @@ if __name__ == "__main__":
     cli.add_argument("first", type=str)
     cli.add_argument("extra", nargs="*", type=str)
     cli.add_argument("output", nargs="?", default="out.jelly", type=str)
+    cli.add_argument("--graphs", action="store_true")
     args = cli.parse_args()
     quads = args.first.endswith(".nq")
-    if quads or args.extra:
-        serialize_dataset(
+    if quads or args.extra or args.graphs:
+        write_dataset(
             [args.first, *args.extra],
-            output=args.output,
-            quads=args.first.endswith(".nq"),
+            output_filename=args.output,
+            quads=not args.graphs,
         )
     else:
-        serialize_graph(args.first, output=args.output)
+        write_graph(args.first, output_filename=args.output)


### PR DESCRIPTION
Cleaner and correct handling of what the expected outcomes can be.
This is just a test script, so we don't need a careful domain-specific review.

I only expect `.nt`, `.nq` or `.ttl` files as the inputs.
I only expect one `.jelly` file as the output.

Single NT/TTL files are serialized as flat triples, NQ files are absorbed to a dataset and serialized as named graphs or quads (depending on the `--graphs` option). Multiple NT/TTL are merged as well and the graphs are named as their filenames, as well serialized as named graphs or quads. NT/TTL and NQ files can be mixed.