### PR TITLE
Workaround prepopulated plugin cache in RDFLib

### DIFF
--- a/tests/integration_tests/test_rdflib_discovery.py
+++ b/tests/integration_tests/test_rdflib_discovery.py
@@ -1,8 +1,12 @@
 import io
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 from rdflib import Graph
+from rdflib import plugin as rdflib_plugin
+from rdflib.parser import Parser as RDFLibParser
+from rdflib.serializer import Serializer as RDFLibSerializer
 
 from pyjelly import options
 
@@ -10,9 +14,17 @@ rdflib_entrypoint_names = ("jelly", *options.MIMETYPES)
 all_entrypoints = pytest.mark.parametrize("file_format", rdflib_entrypoint_names)
 
 
+def workaround_prepopulated_cache(plugin_name: str, extension_class: type[Any]) -> None:
+    # RDFLib caches plugin classes, so a mock is unable to work
+    # if the plugin class was already used by some other test.
+    plugin = rdflib_plugin._plugins[(plugin_name, extension_class)]
+    plugin._class = None
+
+
 @all_entrypoints
 @patch("pyjelly.integrations.rdflib.serializer.RDFLibJellySerializer")
 def test_jelly_serializer_discovered(mock: MagicMock, file_format: str) -> None:
+    workaround_prepopulated_cache(file_format, RDFLibSerializer)
     graph = Graph()
     graph.serialize(format=file_format)
     mock.assert_called_once_with(graph)
@@ -22,6 +34,7 @@ def test_jelly_serializer_discovered(mock: MagicMock, file_format: str) -> None:
 @all_entrypoints
 @patch("pyjelly.integrations.rdflib.parser.RDFLibJellyParser")
 def test_jelly_parser_discovered(mock: MagicMock, file_format: str) -> None:
+    workaround_prepopulated_cache(file_format, RDFLibParser)
     graph = Graph()
     graph.parse(io.StringIO(), format=file_format)
     mock.assert_called_once_with()


### PR DESCRIPTION
These tests can't really be isolated unless run in separate interpreters (I'm not maintaining that)