### PR TITLE
Consuming: Implement QUADS physical type

### DIFF
--- a/pyjelly/consuming/__init__.py
+++ b/pyjelly/consuming/__init__.py
@@ -1,16 +1,19 @@
 from pyjelly import jelly
-from pyjelly.options import StreamOptions
+from pyjelly.options import ConsumerStreamOptions
 
 
 def options_from_frame(
     frame: jelly.RdfStreamFrame, *, delimited: bool
-) -> StreamOptions:
+) -> ConsumerStreamOptions:
     row = frame.rows[0]
-    return StreamOptions(
-        stream_name=row.options.stream_name,
-        version=row.options.version,
-        name_lookup_size=row.options.max_name_table_size,
-        prefix_lookup_size=row.options.max_prefix_table_size,
-        datatype_lookup_size=row.options.max_datatype_table_size,
+    options = row.options
+    return ConsumerStreamOptions(
+        stream_name=options.stream_name,
+        version=options.version,
+        name_lookup_size=options.max_name_table_size,
+        prefix_lookup_size=options.max_prefix_table_size,
+        datatype_lookup_size=options.max_datatype_table_size,
         delimited=delimited,
+        physical_type=options.physical_type,
+        logical_type=options.logical_type,
     )

--- a/pyjelly/consuming/decoder.py
+++ b/pyjelly/consuming/decoder.py
@@ -65,6 +65,9 @@ class Decoder:
         prefix = self.prefixes.decode_prefix_term_index(iri.prefix_id)
         return self.transform_iri(iri=prefix + name)
 
+    def decode_default_graph(self, _: jelly.RdfDefaultGraph) -> Any:
+        return self.transform_default_graph()
+
     def decode_bnode(self, bnode: str) -> Any:
         return self.transform_bnode(bnode)
 
@@ -86,6 +89,9 @@ class Decoder:
     def transform_iri(self, iri: str) -> Any:
         raise NotImplementedError
 
+    def transform_default_graph(self) -> Any:
+        raise NotImplementedError
+
     def transform_bnode(self, bnode: str) -> Any:
         raise NotImplementedError
 
@@ -97,7 +103,7 @@ class Decoder:
     ) -> Any:
         raise NotImplementedError
 
-    row_handlers: ClassVar[dict[Any, Any]] = {
+    row_handlers: ClassVar = {
         jelly.RdfStreamOptions: validate_stream_options,
         jelly.RdfPrefixEntry: ingest_prefix_entry,
         jelly.RdfNameEntry: ingest_name_entry,
@@ -110,4 +116,5 @@ class Decoder:
         jelly.RdfIri: decode_iri,
         str: decode_bnode,
         jelly.RdfLiteral: decode_literal,
+        jelly.RdfDefaultGraph: decode_default_graph,
     }

--- a/pyjelly/consuming/ioutils.py
+++ b/pyjelly/consuming/ioutils.py
@@ -6,7 +6,7 @@ from google.protobuf.proto import parse, parse_length_prefixed
 
 from pyjelly import jelly
 from pyjelly.consuming import options_from_frame
-from pyjelly.options import StreamOptions
+from pyjelly.options import ConsumerStreamOptions
 
 
 def delimited_jelly_hint(header: bytes) -> bool:
@@ -63,7 +63,7 @@ def chained_frame_iterator(
 
 def get_options_and_frames(
     input_stream: IO[bytes],
-) -> tuple[StreamOptions, Iterator[jelly.RdfStreamFrame]]:
+) -> tuple[ConsumerStreamOptions, Iterator[jelly.RdfStreamFrame]]:
     is_delimited = delimited_jelly_hint(bytes_read := input_stream.read(3))
     input_stream.seek(-len(bytes_read), os.SEEK_CUR)
 

--- a/pyjelly/consuming/ioutils.py
+++ b/pyjelly/consuming/ioutils.py
@@ -1,0 +1,77 @@
+import os
+from collections.abc import Generator, Iterator
+from typing import IO
+
+from google.protobuf.proto import parse, parse_length_prefixed
+
+from pyjelly import jelly
+from pyjelly.consuming import options_from_frame
+from pyjelly.options import StreamOptions
+
+
+def delimited_jelly_hint(header: bytes) -> bool:
+    """
+    Detect whether a Jelly file is delimited from its first 3 bytes.
+
+    Truth table (notation: `0A` = `0x0A`, `NN` = `not 0x0A`, `??` = _don't care_):
+
+    | Byte 1 | Byte 2 | Byte 3 | Result                                   |
+    |--------|--------|--------|------------------------------------------|
+    | `NN`   |  `??`  |  `??`  | Delimited                                |
+    | `0A`   |  `NN`  |  `??`  | Non-delimited                            |
+    | `0A`   |  `0A`  |  `NN`  | Delimited (size = 10)                    |
+    | `0A`   |  `0A`  |  `0A`  | Non-delimited (stream options size = 10) |
+
+    >>> delimited_jelly_hint(bytes([0x00, 0x00, 0x00]))
+    True
+
+    >>> delimited_jelly_hint(bytes([0x00, 0x00, 0x0A]))
+    True
+
+    >>> delimited_jelly_hint(bytes([0x00, 0x0A, 0x00]))
+    True
+
+    >>> delimited_jelly_hint(bytes([0x00, 0x0A, 0x0A]))
+    True
+
+    >>> delimited_jelly_hint(bytes([0x0A, 0x00, 0x00]))
+    False
+
+    >>> delimited_jelly_hint(bytes([0x0A, 0x00, 0x0A]))
+    False
+
+    >>> delimited_jelly_hint(bytes([0x0A, 0x0A, 0x00]))
+    True
+
+    >>> delimited_jelly_hint(bytes([0x0A, 0x0A, 0x0A]))
+    False
+    """
+    magic = 0x0A
+    return len(header) == 3 and (  # noqa: PLR2004
+        header[0] != magic or (header[1] == magic and header[2] != magic)
+    )
+
+
+def chained_frame_iterator(
+    first_frame: jelly.RdfStreamFrame,
+    input_stream: IO[bytes],
+) -> Generator[jelly.RdfStreamFrame]:
+    yield first_frame
+    while frame := parse_length_prefixed(jelly.RdfStreamFrame, input_stream):
+        yield frame
+
+
+def get_options_and_frames(
+    input_stream: IO[bytes],
+) -> tuple[StreamOptions, Iterator[jelly.RdfStreamFrame]]:
+    is_delimited = delimited_jelly_hint(bytes_read := input_stream.read(3))
+    input_stream.seek(-len(bytes_read), os.SEEK_CUR)
+
+    if is_delimited:
+        first_frame = parse_length_prefixed(jelly.RdfStreamFrame, input_stream)
+        options = options_from_frame(first_frame, delimited=True)
+        return options, chained_frame_iterator(first_frame, input_stream)
+
+    first_frame = parse(jelly.RdfStreamFrame, input_stream.read())
+    options = options_from_frame(first_frame, delimited=False)
+    return options, iter((first_frame,))

--- a/pyjelly/options.py
+++ b/pyjelly/options.py
@@ -41,7 +41,9 @@ class StreamOptions:
     name_lookup_size: int
     prefix_lookup_size: int
     datatype_lookup_size: int
-    version: int
+    generalized_statements: bool = False
+    rdf_star: bool = False
+    version: int = 1
     delimited: bool = True
     stream_name: str | None = None
 
@@ -56,7 +58,6 @@ class StreamOptions:
             name_lookup_size=128,
             prefix_lookup_size=32,
             datatype_lookup_size=32,
-            version=1,
         )
 
     @classmethod
@@ -65,5 +66,4 @@ class StreamOptions:
             name_lookup_size=DEFAULT_NAME_LOOKUP_SIZE,
             prefix_lookup_size=DEFAULT_PREFIX_LOOKUP_SIZE,
             datatype_lookup_size=DEFAULT_DATATYPE_LOOKUP_SIZE,
-            version=1,
         )

--- a/pyjelly/options.py
+++ b/pyjelly/options.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import mimetypes
 from dataclasses import dataclass
-from typing import Final
-from typing_extensions import Self
+from typing import Any, Final
+
+from pyjelly import jelly
 
 MIN_NAME_LOOKUP_SIZE: Final[int] = 8
 
@@ -52,18 +53,34 @@ class StreamOptions:
             "name lookup size must be at least 8"
         )
 
-    @classmethod
-    def small(cls) -> Self:
-        return cls(
+    @staticmethod
+    def small() -> StreamOptions:
+        return StreamOptions(
             name_lookup_size=128,
             prefix_lookup_size=32,
             datatype_lookup_size=32,
         )
 
-    @classmethod
-    def big(cls) -> Self:
-        return cls(
+    @staticmethod
+    def big() -> StreamOptions:
+        return StreamOptions(
             name_lookup_size=DEFAULT_NAME_LOOKUP_SIZE,
             prefix_lookup_size=DEFAULT_PREFIX_LOOKUP_SIZE,
             datatype_lookup_size=DEFAULT_DATATYPE_LOOKUP_SIZE,
         )
+
+
+class ConsumerStreamOptions(StreamOptions):
+    physical_type: jelly.PhysicalStreamType
+    logical_type: jelly.LogicalStreamType
+
+    def __init__(
+        self,
+        *,
+        physical_type: jelly.PhysicalStreamType,
+        logical_type: jelly.LogicalStreamType,
+        **kwds: Any,
+    ) -> None:
+        super().__init__(**kwds)
+        self.physical_type = physical_type
+        self.logical_type = logical_type

--- a/tests/parse.py
+++ b/tests/parse.py
@@ -6,13 +6,11 @@ import argparse
 
 import rdflib
 
-from tests.utils.ordered_memory import OrderedMemory
-
 
 def main(location: str, output: str) -> None:
-    graph = rdflib.Graph(store=OrderedMemory())
+    graph = rdflib.Dataset()
     graph.parse(location=location, format="jelly")
-    graph.serialize(output, format="jelly")
+    graph.serialize(output, quads=True, format="jelly")
 
 
 if __name__ == "__main__":

--- a/tests/unit_tests/test_serializing/test_lookups/test_options.py
+++ b/tests/unit_tests/test_serializing/test_lookups/test_options.py
@@ -15,5 +15,4 @@ def test_name_encoder_fails_with_size_lt_8(invalid_size: int) -> None:
             name_lookup_size=invalid_size,
             prefix_lookup_size=0,
             datatype_lookup_size=0,
-            version=1,
         )


### PR DESCRIPTION
~~Trust me bro~~ Tested against https://gist.github.com/bswck/520bb5366b09952908f07bc80d2972b7, validated with `jelly rdf validate --compare-to-rdf-file`.

Necessary for #47.
