### PR TITLE
Producing: Namespace declarations

### DIFF
--- a/pyjelly/integrations/rdflib/serializer.py
+++ b/pyjelly/integrations/rdflib/serializer.py
@@ -65,6 +65,8 @@ class RDFLibJellySerializer(RDFLibSerializer):
             encoder_class=RDFLibTermEncoder,
         )
         stream.begin()
+        for prefix, namespace in self.store.namespaces():
+            stream.namespace_declaration(name=prefix, iri=namespace)
         for terms in self.store:
             if frame := stream.triple(terms):
                 yield frame
@@ -84,6 +86,8 @@ class RDFLibJellySerializer(RDFLibSerializer):
             encoder_class=RDFLibTermEncoder,
         )
         stream.begin()
+        for prefix, namespace in self.store.namespaces():
+            stream.namespace_declaration(name=prefix, iri=namespace)
         for terms in self.store.quads():
             if frame := stream.quad(terms):
                 yield frame
@@ -103,6 +107,8 @@ class RDFLibJellySerializer(RDFLibSerializer):
             encoder_class=RDFLibTermEncoder,
         )
         stream.begin()
+        for prefix, namespace in self.store.namespaces():
+            stream.namespace_declaration(name=prefix, iri=namespace)
         for graph in self.store.graphs():
             yield from stream.graph(graph_id=graph.identifier, graph=graph)
         if last := stream.producer.to_stream_frame():

--- a/pyjelly/producing/__init__.py
+++ b/pyjelly/producing/__init__.py
@@ -8,6 +8,7 @@ from pyjelly.options import StreamOptions
 from pyjelly.producing.encoder import (
     Slot,
     TermEncoder,
+    encode_namespace_declaration,
     encode_quad,
     encode_triple,
     new_repeated_terms,
@@ -57,6 +58,14 @@ class Stream:
     def begin(self) -> None:
         row = jelly.RdfStreamRow(options=self.encode_options())
         self.producer.add_stream_rows((row,))
+
+    def namespace_declaration(self, name: str, iri: str) -> None:
+        rows = encode_namespace_declaration(
+            name=name,
+            value=iri,
+            term_encoder=self.encoder,
+        )
+        self.producer.add_stream_rows(rows)
 
 
 class TripleStream(Stream):

--- a/pyjelly/producing/__init__.py
+++ b/pyjelly/producing/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator, Iterable
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from pyjelly import jelly
 from pyjelly.options import StreamOptions
@@ -108,9 +108,8 @@ class GraphStream(TripleStream):
     ) -> Generator[jelly.RdfStreamFrame]:
         [*graph_rows], graph_node = self.encoder.encode_any(graph_id, Slot.graph)
         kw_name = f"{Slot.graph}_{self.encoder.TERM_ONEOF_NAMES[type(graph_node)]}"
-        start_row = jelly.RdfStreamRow(
-            graph_start=jelly.RdfGraphStart(**{kw_name: graph_node})
-        )
+        kws: dict[Any, Any] = {kw_name: graph_node}
+        start_row = jelly.RdfStreamRow(graph_start=jelly.RdfGraphStart(**kws))
         graph_rows.append(start_row)
         self.producer.add_stream_rows(graph_rows)
         for triple in graph:

--- a/pyjelly/producing/__init__.py
+++ b/pyjelly/producing/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator, Iterable
-from typing import Any
+from typing import ClassVar
 
 from pyjelly import jelly
 from pyjelly.options import StreamOptions
@@ -12,38 +12,55 @@ from pyjelly.producing.encoder import (
     encode_triple,
     new_repeated_terms,
 )
-from pyjelly.producing.producers import FrameProducer
+from pyjelly.producing.producers import FlatFrameProducer, FrameProducer
 
 
 class Stream:
+    physical_type: ClassVar[jelly.PhysicalStreamType]
+
     def __init__(
         self,
         *,
-        encoder: TermEncoder,
-        producer: FrameProducer,
-        physical_type: jelly.PhysicalStreamType,
+        options: StreamOptions,
+        encoder_class: type[TermEncoder],
+        producer: FrameProducer | None = None,
     ) -> None:
-        self.encoder = encoder
-        self.producer = producer
-        self.physical_type = physical_type
+        self.options = options
+        self.encoder = encoder_class(
+            prefix_lookup_size=options.prefix_lookup_size,
+            name_lookup_size=options.name_lookup_size,
+            datatype_lookup_size=options.datatype_lookup_size,
+        )
+        self.producer = producer or self.create_default_producer()
         self.repeated_terms = new_repeated_terms()
 
-    def create_jelly_options(self, options: StreamOptions) -> jelly.RdfStreamOptions:
+    def create_default_producer(self) -> FrameProducer:
+        quads = self.physical_type != jelly.PHYSICAL_STREAM_TYPE_TRIPLES
+        return FlatFrameProducer(quads=quads)
+
+    def calculate_version(self) -> int:
+        return 1
+
+    def encode_options(self) -> jelly.RdfStreamOptions:
         return jelly.RdfStreamOptions(
-            stream_name=options.stream_name,
+            stream_name=self.options.stream_name,
             physical_type=self.physical_type,
-            generalized_statements=True,
-            rdf_star=False,
-            max_name_table_size=options.name_lookup_size,
-            max_prefix_table_size=options.prefix_lookup_size,
-            max_datatype_table_size=options.datatype_lookup_size,
+            generalized_statements=self.options.generalized_statements,
+            rdf_star=self.options.rdf_star,
+            max_name_table_size=self.options.name_lookup_size,
+            max_prefix_table_size=self.options.prefix_lookup_size,
+            max_datatype_table_size=self.options.datatype_lookup_size,
             logical_type=self.producer.jelly_type,
-            version=1,
+            version=self.options.version,
         )
 
-    def begin(self, options: StreamOptions) -> None:
-        row = jelly.RdfStreamRow(options=self.create_jelly_options(options))
+    def begin(self) -> None:
+        row = jelly.RdfStreamRow(options=self.encode_options())
         self.producer.add_stream_rows((row,))
+
+
+class TripleStream(Stream):
+    physical_type = jelly.PHYSICAL_STREAM_TYPE_TRIPLES
 
     def triple(self, terms: Iterable[object]) -> jelly.RdfStreamFrame | None:
         new_rows = encode_triple(
@@ -56,6 +73,10 @@ class Stream:
             return self.producer.to_stream_frame()
         return None
 
+
+class QuadStream(Stream):
+    physical_type = jelly.PHYSICAL_STREAM_TYPE_QUADS
+
     def quad(self, terms: Iterable[object]) -> jelly.RdfStreamFrame | None:
         new_rows = encode_quad(
             terms,
@@ -67,17 +88,21 @@ class Stream:
             return self.producer.to_stream_frame()
         return None
 
+
+class GraphStream(TripleStream):
+    physical_type = jelly.PHYSICAL_STREAM_TYPE_GRAPHS
+
     def graph(
         self,
         graph_id: object,
         graph: Iterable[Iterable[object]],
     ) -> Generator[jelly.RdfStreamFrame]:
         [*graph_rows], graph_node = self.encoder.encode_any(graph_id, Slot.graph)
-        marker_kwargs: dict[str, Any] = {
-            f"g_{self.encoder.TERM_ONEOF_NAMES[type(graph_node)]}": graph_node
-        }
-        graph_row = jelly.RdfStreamRow(graph_start=jelly.RdfGraphStart(**marker_kwargs))
-        graph_rows.append(graph_row)
+        kw_name = f"{Slot.graph}_{self.encoder.TERM_ONEOF_NAMES[type(graph_node)]}"
+        start_row = jelly.RdfStreamRow(
+            graph_start=jelly.RdfGraphStart(**{kw_name: graph_node})
+        )
+        graph_rows.append(start_row)
         self.producer.add_stream_rows(graph_rows)
         for triple in graph:
             if frame := self.triple(triple):

--- a/pyjelly/producing/encoder.py
+++ b/pyjelly/producing/encoder.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from enum import Enum
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TypeVar
 from typing_extensions import TypeAlias
 
 from pyjelly import jelly, options
@@ -19,10 +19,11 @@ def split_iri(iri_string: str) -> tuple[str, str]:
     return prefix, name
 
 
-RowsAndTerm: TypeAlias = tuple[
-    Sequence[jelly.RdfStreamRow],
-    "jelly.RdfIri | jelly.RdfLiteral | str | jelly.RdfDefaultGraph",
-]
+TermT = TypeVar("TermT")
+RowsAnd: TypeAlias = tuple[Sequence[jelly.RdfStreamRow], TermT]
+RowsAndTerm: TypeAlias = (
+    "RowsAnd[jelly.RdfIri | jelly.RdfLiteral | str | jelly.RdfDefaultGraph]"
+)
 
 
 class TermEncoder:
@@ -43,7 +44,7 @@ class TermEncoder:
         self.prefixes = LookupEncoder(lookup_size=prefix_lookup_size)
         self.datatypes = LookupEncoder(lookup_size=datatype_lookup_size)
 
-    def encode_iri(self, iri_string: str) -> RowsAndTerm:
+    def encode_iri(self, iri_string: str) -> RowsAnd[jelly.RdfIri]:
         prefix, name = split_iri(iri_string)
         prefix_id = self.prefixes.encode_entry_index(prefix)
         name_id = self.names.encode_entry_index(name)
@@ -61,10 +62,10 @@ class TermEncoder:
         name_id = self.names.encode_name_term_index(name)
         return term_rows, jelly.RdfIri(prefix_id=prefix_id, name_id=name_id)
 
-    def encode_default_graph(self) -> RowsAndTerm:
+    def encode_default_graph(self) -> RowsAnd[jelly.RdfDefaultGraph]:
         return (), jelly.RdfDefaultGraph()
 
-    def encode_bnode(self, bnode: str) -> RowsAndTerm:
+    def encode_bnode(self, bnode: str) -> RowsAnd[str]:
         return (), bnode
 
     def encode_literal(
@@ -73,7 +74,7 @@ class TermEncoder:
         lex: str,
         language: str | None = None,
         datatype: str | None = None,
-    ) -> RowsAndTerm:
+    ) -> RowsAnd[jelly.RdfLiteral]:
         datatype_id = None
         term_rows: tuple[()] | tuple[jelly.RdfStreamRow] = ()
 

--- a/pyjelly/producing/encoder.py
+++ b/pyjelly/producing/encoder.py
@@ -109,12 +109,6 @@ class Slot(str, Enum):
         return self.value
 
 
-STATEMENT_ONEOF_NAMES = {
-    jelly.RdfTriple: "triple",
-    jelly.RdfQuad: "quad",
-}
-
-
 def new_repeated_terms() -> dict[Slot, object]:
     """Create a new dictionary for repeated terms."""
     return dict.fromkeys(Slot)
@@ -156,5 +150,17 @@ def encode_triple(
 ) -> list[jelly.RdfStreamRow]:
     rows, statement = encode_statement(terms, term_encoder, repeated_terms)
     row = jelly.RdfStreamRow(triple=jelly.RdfTriple(**statement))
+    rows.append(row)
+    return rows
+
+
+def encode_namespace_declaration(
+    name: str,
+    value: str,
+    term_encoder: TermEncoder,
+) -> list[jelly.RdfStreamRow]:
+    [*rows], iri = term_encoder.encode_iri(value)
+    declaration = jelly.RdfNamespaceDeclaration(name=name, value=iri)
+    row = jelly.RdfStreamRow(namespace=declaration)
     rows.append(row)
     return rows

--- a/pyjelly/producing/ioutils.py
+++ b/pyjelly/producing/ioutils.py
@@ -1,0 +1,13 @@
+from typing import IO
+
+from google.protobuf.proto import serialize_length_prefixed
+
+from pyjelly import jelly
+
+
+def write_delimited(frame: jelly.RdfStreamFrame, output_stream: IO[bytes]) -> None:
+    serialize_length_prefixed(frame, output_stream)
+
+
+def write_single(frame: jelly.RdfStreamFrame, output_stream: IO[bytes]) -> None:
+    output_stream.write(frame.SerializeToString(deterministic=True))

--- a/tests/serialize.py
+++ b/tests/serialize.py
@@ -7,47 +7,89 @@ from pathlib import Path
 
 import rdflib
 
+from pyjelly.consuming.ioutils import get_options_and_frames
+from pyjelly.options import StreamOptions
 from tests.utils.ordered_memory import OrderedMemory
 
 
 def write_dataset(
-    filenames: list[str],
-    output_filename: str | Path,
+    filenames: list[str | Path],
+    out_filename: str | Path,
     *,
     quads: bool = False,
+    options_from: str | Path | None = None,
 ) -> None:
+    options = get_options_from(options_from)
     dataset = rdflib.Dataset()
-    for filename in filenames:
+    for filename in map(str, filenames):
         if filename.endswith(".nq"):
             dataset.parse(location=filename)
         else:
             graph = rdflib.Graph(identifier=filename, store=OrderedMemory())
             graph.parse(location=filename)
             dataset.add_graph(graph)
-    with Path(output_filename).open("wb") as file:
-        dataset.serialize(destination=file, quads=quads, format="jelly")
+    with Path(out_filename).open("wb") as file:
+        dataset.serialize(
+            destination=file,
+            quads=quads,
+            format="jelly",
+            options=options,
+        )
 
 
-def write_graph(filename: str, output_filename: str | Path) -> None:
+def write_graph(
+    filename: str | Path,
+    out_filename: str | Path,
+    options_from: str | Path | None = None,
+) -> None:
+    options = get_options_from(options_from)
     graph = rdflib.Graph(store=OrderedMemory())
-    graph.parse(location=filename)
-    with Path(output_filename).open("wb") as file:
-        graph.serialize(destination=file, format="jelly")
+    graph.parse(location=str(filename))
+    with Path(out_filename).open("wb") as file:
+        graph.serialize(destination=file, format="jelly", options=options)
+
+
+def get_options_from(
+    options_filename: str | Path | None = None,
+) -> StreamOptions | None:
+    if options_filename is not None:
+        with Path(options_filename).open("rb") as options_file:
+            options, _ = get_options_and_frames(options_file)
+    else:
+        options = None
+    return options
+
+
+def write_graph_or_dataset(
+    first: str | Path,
+    *extra: str | Path,
+    graphs: bool = False,
+    out_filename: str | Path = "out.jelly",
+    options_from: str | Path | None = None,
+) -> None:
+    if str(first).endswith(".nq") or extra or graphs:
+        write_dataset(
+            [first, *extra],
+            out_filename=out_filename,
+            quads=not graphs,
+            options_from=options_from,
+        )
+    else:
+        write_graph(first, out_filename=out_filename, options_from=options_from)
 
 
 if __name__ == "__main__":
     cli = argparse.ArgumentParser()
     cli.add_argument("first", type=str)
     cli.add_argument("extra", nargs="*", type=str)
-    cli.add_argument("output", nargs="?", default="out.jelly", type=str)
+    cli.add_argument("out", nargs="?", default="out.jelly", type=str)
     cli.add_argument("--graphs", action="store_true")
+    cli.add_argument("--options-from", type=str)
     args = cli.parse_args()
-    quads = args.first.endswith(".nq")
-    if quads or args.extra or args.graphs:
-        write_dataset(
-            [args.first, *args.extra],
-            output_filename=args.output,
-            quads=not args.graphs,
-        )
-    else:
-        write_graph(args.first, output_filename=args.output)
+    write_graph_or_dataset(
+        args.first,
+        *args.extra,
+        graphs=args.graphs,
+        out_filename=args.out,
+        options_from=args.options_from,
+    )


### PR DESCRIPTION
Closes #34

I forced the serialized graph to yield namespaces on `.namespaces()` using the snippet below

```py
from rdflib import Graph
from rdflib.namespace import Namespace, NamespaceManager

EX = Namespace("http://example.com/")
namespace_manager = NamespaceManager(Graph())
namespace_manager.bind("ex", EX, override=False)
graph.namespace_manager = namespace_manager
```

I only need to check if this is correct:

<details>

```c
rows {
  namespace {
    name: "brick"
    value {
      prefix_id: 1
      name_id: 0
    }
  }
}
rows {
  prefix {
    id: 0
    value: "http://www.w3.org/ns/csvw#"
  }
}
rows {
  namespace {
    name: "csvw"
    value {
      prefix_id: 2
      name_id: 1
    }
  }
}
rows {
  prefix {
    id: 0
    value: "http://purl.org/dc/elements/1.1/"
  }
}
rows {
  namespace {
    name: "dc"
    value {
      prefix_id: 3
      name_id: 1
    }
  }
}
rows {
  prefix {
    id: 0
    value: "http://www.w3.org/ns/dcat#"
  }
}
rows {
  namespace {
    name: "dcat"
    value {
      prefix_id: 4
      name_id: 1
    }
  }
}
rows {
  prefix {
    id: 0
    value: "http://purl.org/dc/dcmitype/"
  }
}
rows {
  namespace {
    name: "dcmitype"
    value {
      prefix_id: 5
      name_id: 1
    }
  }
}
rows {
  prefix {
    id: 0
    value: "http://purl.org/dc/terms/"
  }
}
rows {
  namespace {
    name: "dcterms"
    value {
      prefix_id: 6
      name_id: 1
    }
  }
}
rows {
  prefix {
    id: 0
    value: "http://purl.org/dc/dcam/"
  }
}
rows {
  namespace {
    name: "dcam"
    value {
      prefix_id: 7
      name_id: 1
    }
  }
}
```

</details>