### PR TITLE
Expand submodules in CI

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -34,7 +34,6 @@ jobs:
         platform:
         - ubuntu-latest
         - macos-latest
-        - windows-latest
         include:
         - version: '3.10'
           platform: ubuntu-latest
@@ -55,6 +54,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
 
     - uses: astral-sh/setup-uv@v5
       with:


### PR DESCRIPTION
In https://github.com/Jelly-RDF/pyjelly/actions/runs/14731895436/job/41347988000, I learned that you cannot stat symlinks on Windows in GitHub Actions:

<details>

<summary>Permanent log</summary>

```
Run astral-sh/setup-uv@v5
Found required-version for uv in pyproject.toml: 0.6.17
Downloading uv from "https://github.com/astral-sh/uv/releases/download/0.6.17/uv-x86_64-pc-windows-msvc.zip" ...
"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\8997fdc5-0e52-46bc-9283-e615086301f7.zip', 'D:\a\_temp\5a7c20ea-1b05-4832-bb4d-1408b763bec3', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'D:\a\_temp\8997fdc5-0e52-46bc-9283-e615086301f7.zip' -DestinationPath 'D:\a\_temp\5a7c20ea-1b05-4832-bb4d-1408b763bec3' -Force } else { throw $_ } } ;"
Set UV_TOOL_BIN_DIR to D:\a\_temp\uv-tool-bin-dir
Added D:\a\_temp\uv-tool-bin-dir to the path
Added C:\hostedtoolcache\windows\uv\0.6.17\x86_64 to the path
Set UV_TOOL_DIR to D:\a\_temp\uv-tool-dir
Set UV_CACHE_DIR to D:\a\_temp\setup-uv-cache
Successfully installed uv version 0.6.17
Searching files using cache dependency glob: **/uv.lock,**/requirements*.txt
Error: EPERM: operation not permitted, stat 'D:\a\pyjelly\pyjelly\pyjelly\_proto'
```

</details>

(`_proto` is a symlink to a submodule we otherwise don't expand, without checkout with `submodules: true`)

Even if we change the globbed path to not have the `**` wildcard (which skips non-top-level symlinks), this is still an icky workaround that would potentially hit us back like a boomerang at some point.

I'll defer dealing with that for now--I removed the support for Windows and set the submodules to be expanded to be installed in every action. If we don't expand submodules, not only running test cases but even collecting them will fail.
