### PR TITLE
Refactor logical types

### DIFF
--- a/pyjelly/producing/__init__.py
+++ b/pyjelly/producing/__init__.py
@@ -13,7 +13,11 @@ from pyjelly.producing.encoder import (
     encode_triple,
     new_repeated_terms,
 )
-from pyjelly.producing.producers import FlatFrameProducer, FrameProducer
+from pyjelly.producing.producers import (
+    FlatFrameProducer,
+    FrameProducer,
+    ManualFrameProducer,
+)
 
 
 class Stream:
@@ -32,7 +36,11 @@ class Stream:
             name_lookup_size=options.name_lookup_size,
             datatype_lookup_size=options.datatype_lookup_size,
         )
-        self.producer = producer or self.create_default_producer()
+        self.producer = (
+            producer or self.create_default_producer()
+            if options.delimited
+            else ManualFrameProducer()
+        )
         validate_type_compatibility(self.physical_type, self.producer.jelly_type)
         self.repeated_terms = new_repeated_terms()
 

--- a/pyjelly/producing/producers.py
+++ b/pyjelly/producing/producers.py
@@ -18,7 +18,7 @@ class FrameProducer(metaclass=ABCMeta):
     """
 
     def __init__(self) -> None:
-        self._rows = []
+        self._rows: list[jelly.RdfStreamRow] = []
 
     def add_stream_rows(self, rows: Iterable[jelly.RdfStreamRow]) -> None:
         """Add stream rows to the current batch."""

--- a/pyjelly/producing/producers.py
+++ b/pyjelly/producing/producers.py
@@ -33,11 +33,7 @@ class FrameProducer(metaclass=ABCMeta):
     @property
     @abstractmethod
     def jelly_type(self) -> jelly.LogicalStreamType:
-        """
-        Return the logical stream type for this producer.
-
-        Defaults to flat triples.
-        """
+        """Return the logical stream type for this producer."""
         raise NotImplementedError
 
     def to_stream_frame(self) -> jelly.RdfStreamFrame | None:

--- a/pyjelly/producing/producers.py
+++ b/pyjelly/producing/producers.py
@@ -63,7 +63,12 @@ class ManualFrameProducer(FrameProducer):
         jelly_type: jelly.LogicalStreamType = jelly.LOGICAL_STREAM_TYPE_UNSPECIFIED,
     ) -> None:
         super().__init__()
-        self.jelly_type = jelly_type
+        self._jelly_type = jelly_type
+
+    @property
+    @override
+    def jelly_type(self) -> jelly.LogicalStreamType:
+        return self._jelly_type
 
     @property
     @override

--- a/pyjelly/producing/producers.py
+++ b/pyjelly/producing/producers.py
@@ -27,13 +27,18 @@ class FrameProducer(metaclass=ABCMeta):
     @property
     @abstractmethod
     def stream_frame_ready(self) -> bool:
-        """Determine if a new frame should be emitted based on implementation-specific logic."""
+        """Determine if a new frame should be emitted."""
         raise NotImplementedError
 
-    @cached_property
+    @property
+    @abstractmethod
     def jelly_type(self) -> jelly.LogicalStreamType:
-        """Return the logical stream type for this producer. Defaults to flat triples."""
-        return jelly.LOGICAL_STREAM_TYPE_FLAT_TRIPLES
+        """
+        Return the logical stream type for this producer.
+
+        Defaults to flat triples.
+        """
+        raise NotImplementedError
 
     def to_stream_frame(self) -> jelly.RdfStreamFrame | None:
         """Return the current frame and clears the row buffer if there are any rows."""


### PR DESCRIPTION
This renames `FlatFrameProducer` with always-`False` readiness checker to `ManualFrameProducer` and forces non-delimited writing to stay in a single frame at all times (and in memory, too).