### PR TITLE
Fix empty prefix encoding

### DIFF
--- a/news/127.fixed.md
+++ b/news/127.fixed.md
@@ -1,0 +1,1 @@
+A bug where empty prefixes were not serialized

--- a/pyjelly/serialize/encode.py
+++ b/pyjelly/serialize/encode.py
@@ -48,14 +48,13 @@ class TermEncoder:
 
     def encode_iri(self, iri_string: str) -> RowsAnd[jelly.RdfIri]:
         prefix, name = split_iri(iri_string)
-        if prefix and self.prefixes.lookup.max_size:
+        if self.prefixes.lookup.max_size:
             prefix_entry_index = self.prefixes.encode_entry_index(prefix)
         else:
             name = iri_string
             prefix_entry_index = None
 
         name_entry_index = self.names.encode_entry_index(name)
-
         term_rows = []
 
         if prefix_entry_index is not None:

--- a/pyjelly/serialize/lookup.py
+++ b/pyjelly/serialize/lookup.py
@@ -108,11 +108,13 @@ class LookupEncoder:
         return current_index
 
     def encode_prefix_term_index(self, value: str) -> int:
-        if not value or self.lookup.max_size == 0:
+        if self.lookup.max_size == 0:
             return 0
         previous_index = self.last_reused_index
+        if not value and previous_index == 0:
+            return 0
         current_index = self.encode_term_index(value)
-        if value and previous_index == 0:
+        if previous_index == 0:
             return current_index
         if current_index == previous_index:
             return 0


### PR DESCRIPTION
Empty prefixes that occured after non-empty prefixes weren't encoded at all.