### PR TITLE
Loosen the requirement on uv version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ docs = [
 ]
 
 [tool.uv]
-required-version = "==0.7.3"
+required-version = "~=0.7.3"
 default-groups = ["dev", "extras", "test", "types"]
 
 [tool.mypy]


### PR DESCRIPTION
I tried to get started using

```
pip install uv
uv sync
```

but I got this

```
@Ostrzyciel ➜ /workspaces/pyjelly (main) $ uv sync
error: Required uv version `==0.7.3` does not match the running version `0.7.10`. Update `uv` by running `uv self update 0.7.3`.
```

which sounds like a very petty error, as I would expect uv 0.7.10 to work fine.

Unless there's a very good reason for this, I'd make the requirement looser.