### PR TITLE
Add link to licensing & citation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,4 +125,5 @@ nav:
       - "contributing/index.md"
       - Code of conduct: "contributing/code_of_conduct.md"
   - Changelog: "https://github.com/Jelly-RDF/pyjelly/releases"
+  - Licensing and citation: "https://w3id.org/jelly/dev/licensing"
   - Back to main Jelly docs ↩: "https://w3id.org/jelly/"


### PR DESCRIPTION
We can simply redirect to the main docs, there is no need to maintain a separate licensing page for pyjelly at the moment.