### PR TITLE
Add parse flat example to documentation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,14 @@ To process a Jelly stream frame-by-frame, loading each as a separate RDFLib grap
 
 Because `parse_jelly_grouped` returns a generator, each iteration receives **one** graph, keeping memory usage bounded to the current frame. Thus, large datasets and live streams can be processed efficiently.
 
+### Streaming event parser
+
+To process a Jelly stream as a stream of RDFLib triples:
+
+{{ code_example('rdflib/05_parse_flat.py') }}
+
+Here, `parse_jelly_flat` returns a generator of stream events (i.e., statements parsed), allowing for efficient triple-level processing and building custom aggregations from the stream.
+
 ### File extension support
 
 You can generally omit the `format="jelly"` parameter if the file ends in `.jelly` – RDFLib will auto-detect the format:

--- a/examples/rdflib/04_parse_grouped.py
+++ b/examples/rdflib/04_parse_grouped.py
@@ -7,7 +7,7 @@ from typing import cast, IO
 
 from pyjelly.integrations.rdflib.parse import parse_jelly_grouped
 
-url = "https://w3id.org/riverbench/datasets/dbpedia-live/dev/files/jelly_10K.jelly.gz"
+url = "https://w3id.org/riverbench/datasets/lod-katrina/dev/files/jelly_10K.jelly.gz"
 
 # load, uncompress .gz file, and pass to jelly parser
 with (

--- a/examples/rdflib/05_parse_flat.py
+++ b/examples/rdflib/05_parse_flat.py
@@ -1,0 +1,24 @@
+import gzip
+import urllib.request
+from typing import cast, IO
+
+from pyjelly.integrations.rdflib.parse import parse_jelly_flat, Triple
+from rdflib import Graph, URIRef
+
+predicate_to_look_for = URIRef(
+    "http://knoesis.wright.edu/ssw/ont/sensor-observation.owl#floatValue"
+)
+graph_measurements = Graph()
+
+url = "https://w3id.org/riverbench/datasets/lod-katrina/dev/files/jelly_10K.jelly.gz"
+with (
+    urllib.request.urlopen(url) as resp,
+    cast(IO[bytes], gzip.GzipFile(fileobj=resp)) as jelly_stream,
+):
+    events = parse_jelly_flat(jelly_stream)
+    for event in events:
+        if isinstance(event, Triple):  # filter the stream event of interest
+            s, p, o = event
+            if p == predicate_to_look_for:
+                graph_measurements.add(event)
+print(f"Measurements in graph: {len(graph_measurements)}")


### PR DESCRIPTION
Closes #154 

- Added a new example to getting-started on how to iterate over triples and freestyle some processing
- Switched to a different dataset from Riverbench (is smaller and does not have problems with timestamp data)