### PR TITLE
Added support for logical stream subtypes in serialization

### DIFF
--- a/pyjelly/integrations/rdflib/serialize.py
+++ b/pyjelly/integrations/rdflib/serialize.py
@@ -61,7 +61,9 @@ def namespace_declarations(store: Graph, stream: Stream) -> None:
 
 
 @singledispatch
-def stream_frames(stream: Stream, data: Graph) -> Generator[jelly.RdfStreamFrame]:  # noqa: ARG001
+def stream_frames(
+    stream: Stream, data: Graph  # noqa: ARG001
+) -> Generator[jelly.RdfStreamFrame]:
     msg = f"invalid stream implementation {stream}"
     raise TypeError(msg)
 
@@ -200,6 +202,9 @@ class RDFLibJellySerializer(RDFLibSerializer):
         """
         Return an appropriate stream implementation for the given options.
 
+        Notes: if base(!) logical type is GRAPHS and Dataset is given,
+            initializes TripleStream
+
         >>> graph_ser = RDFLibJellySerializer(Graph())
         >>> ds_ser = RDFLibJellySerializer(Dataset())
 
@@ -209,9 +214,9 @@ class RDFLibJellySerializer(RDFLibSerializer):
         <class 'pyjelly.serialize.streams.QuadStream'>
         """
         stream_cls: type[Stream]
-        if options.logical_type != jelly.LOGICAL_STREAM_TYPE_GRAPHS and isinstance(
-            self.store, Dataset
-        ):
+        if (
+            options.logical_type % 10
+        ) != jelly.LOGICAL_STREAM_TYPE_GRAPHS and isinstance(self.store, Dataset):
             stream_cls = QuadStream
         else:
             stream_cls = TripleStream

--- a/pyjelly/serialize/flows.py
+++ b/pyjelly/serialize/flows.py
@@ -153,7 +153,6 @@ class DatasetsFrameFlow(FrameFlow):
         return self.to_stream_frame()
 
 
-# TODO(Nastya): issue #184
 FLOW_DISPATCH: dict[jelly.LogicalStreamType, type[FrameFlow]] = {
     jelly.LOGICAL_STREAM_TYPE_FLAT_TRIPLES: FlatTriplesFrameFlow,
     jelly.LOGICAL_STREAM_TYPE_FLAT_QUADS: FlatQuadsFrameFlow,
@@ -166,18 +165,23 @@ def flow_for_type(logical_type: jelly.LogicalStreamType) -> type[FrameFlow]:
     """
     Return flow based on logical type requested.
 
+    Note: uses base logical type for subtypes (i.e., SUBJECT_GRAPHS uses
+        the same flow as its base type GRAPHS).
+
     Args:
         logical_type (jelly.LogicalStreamType): logical type requested.
 
     Raises:
-        NotImplementedError: if logical type not supported.
+        NotImplementedError: if (base) logical stream type is not supported.
 
     Returns:
         type[FrameFlow]: FrameFlow for respective logical type.
 
     """
     try:
-        return FLOW_DISPATCH[logical_type]
+        base_logical_type_value = logical_type % 10
+        base_name = jelly.LogicalStreamType.Name(base_logical_type_value)
+        return FLOW_DISPATCH[getattr(jelly.LogicalStreamType, base_name)]
     except KeyError:
         msg = (
             "unsupported logical stream type: "

--- a/pyjelly/serialize/flows.py
+++ b/pyjelly/serialize/flows.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import UserList
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import Any, ClassVar
 from typing_extensions import override
 
 from pyjelly import jelly
@@ -16,10 +16,23 @@ class FrameFlow(UserList[jelly.RdfStreamRow]):
     Abstract base class for producing Jelly frames from RDF stream rows.
 
     Collects stream rows and assembles them into RdfStreamFrame objects when ready.
+
+    Allows for passing LogicalStreamType, required for
+        logical subtypes and non-delimited streams.
     """
 
     logical_type: jelly.LogicalStreamType
     registry: ClassVar[dict[jelly.LogicalStreamType, type[FrameFlow]]] = {}
+
+    def __init__(
+        self,
+        initlist: Iterable[jelly.RdfStreamRow] | None = None,
+        *,
+        logical_type: jelly.LogicalStreamType | None = None,
+        **__kwargs: Any,
+    ) -> None:
+        super().__init__(initlist)
+        self.logical_type = logical_type or self.__class__.logical_type
 
     def frame_from_graph(self) -> jelly.RdfStreamFrame | None:
         """
@@ -71,15 +84,6 @@ class ManualFrameFlow(FrameFlow):
 
     logical_type = jelly.LOGICAL_STREAM_TYPE_UNSPECIFIED
 
-    def __init__(
-        self,
-        initlist: Iterable[jelly.RdfStreamRow] | None = None,
-        *,
-        logical_type: jelly.LogicalStreamType = jelly.LOGICAL_STREAM_TYPE_UNSPECIFIED,
-    ) -> None:
-        super().__init__(initlist)
-        self.logical_type = logical_type
-
 
 @dataclass
 class BoundedFrameFlow(FrameFlow):
@@ -92,13 +96,15 @@ class BoundedFrameFlow(FrameFlow):
     logical_type = jelly.LOGICAL_STREAM_TYPE_UNSPECIFIED
     frame_size: int
 
+    @override
     def __init__(
         self,
         initlist: Iterable[jelly.RdfStreamRow] | None = None,
+        logical_type: jelly.LogicalStreamType | None = None,
         *,
         frame_size: int | None = None,
     ) -> None:
-        super().__init__(initlist)
+        super().__init__(initlist, logical_type=logical_type)
         self.frame_size = frame_size or DEFAULT_FRAME_SIZE
 
     @override

--- a/pyjelly/serialize/streams.py
+++ b/pyjelly/serialize/streams.py
@@ -78,9 +78,12 @@ class Stream:
                 jelly.LOGICAL_STREAM_TYPE_FLAT_TRIPLES,
                 jelly.LOGICAL_STREAM_TYPE_FLAT_QUADS,
             ):
-                flow = flow_class(frame_size=self.options.frame_size)  # type: ignore[call-overload]
+                flow = flow_class(
+                    logical_type=self.options.logical_type,
+                    frame_size=self.options.frame_size,
+                )
             else:
-                flow = flow_class()
+                flow = flow_class(logical_type=self.options.logical_type)
         else:
             flow = ManualFrameFlow(logical_type=self.options.logical_type)
         return flow

--- a/tests/unit_tests/test_serialize/test_streams.py
+++ b/tests/unit_tests/test_serialize/test_streams.py
@@ -7,9 +7,13 @@ from pyjelly.errors import JellyAssertionError
 from pyjelly.options import StreamParameters
 from pyjelly.serialize.encode import TermEncoder
 from pyjelly.serialize.flows import (
+    DatasetsFrameFlow,
     FlatQuadsFrameFlow,
     FlatTriplesFrameFlow,
+    FrameFlow,
+    GraphsFrameFlow,
     ManualFrameFlow,
+    flow_for_type,
 )
 from pyjelly.serialize.streams import (
     GraphStream,
@@ -33,6 +37,27 @@ def test_flat_quads_inference_delimited(
     stream = stream_class(encoder=TermEncoder(), options=None)
     assert isinstance(stream.flow, FlatQuadsFrameFlow)
     assert stream.flow.logical_type == jelly.LOGICAL_STREAM_TYPE_FLAT_QUADS
+
+
+@pytest.mark.parametrize(
+    (
+        "logical_type",
+        "flow_type",
+    ),
+    [
+        (jelly.LOGICAL_STREAM_TYPE_FLAT_TRIPLES, FlatTriplesFrameFlow),
+        (jelly.LOGICAL_STREAM_TYPE_FLAT_QUADS, FlatQuadsFrameFlow),
+        (jelly.LOGICAL_STREAM_TYPE_GRAPHS, GraphsFrameFlow),
+        (jelly.LOGICAL_STREAM_TYPE_DATASETS, DatasetsFrameFlow),
+        (jelly.LOGICAL_STREAM_TYPE_SUBJECT_GRAPHS, GraphsFrameFlow),
+        (jelly.LOGICAL_STREAM_TYPE_NAMED_GRAPHS, DatasetsFrameFlow),
+        (jelly.LOGICAL_STREAM_TYPE_TIMESTAMPED_NAMED_GRAPHS, DatasetsFrameFlow),
+    ],
+)
+def test_flow_base_logical_type(
+    logical_type: jelly.LogicalStreamType, flow_type: type[FrameFlow]
+) -> None:
+    assert flow_for_type(logical_type) is flow_type
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #184 

Changes:
- applied modulo 10 operation in flow_for_type to support logical subtypes 
- added a test to check that for all current logical types, a proper flow is spawned