### PR TITLE
Improve the overview doc page

### DIFF
--- a/docs/env.py
+++ b/docs/env.py
@@ -90,7 +90,7 @@ def define_env(env):
     @env.macro
     def git_link(file: str):
         tag = git_tag()
-        return f"https://github.com/Jelly-RDF/jelly-python/blob/{tag}/{file}"
+        return f"https://github.com/Jelly-RDF/pyjelly/blob/{tag}/{file}"
 
     @env.macro
     def proto_version():

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,6 +1,8 @@
 ## What is Jelly and pyjelly?
 
-[Jelly]({{ proto_link() }}) is a high-performance serialization format and streaming protocol for RDF knowledge graphs. It enables fast, compact, and flexible transmission of RDF data with Protobuf, supporting both flat and structured streams of triples, quads, graphs, and datasets. Jelly is designed to work well in both batch and real-time settings, including use over files, sockets, or stream processing systems like Kafka or gRPC.
+**[Jelly]({{ proto_link() }})** is a high-performance serialization format for RDF knowledge graphs and knowledge graph streams. It's designed to be fast, compact, and flexible. 
+
+With Jelly, you can transmit both flat and structured streams of triples, quads, graphs, and datasets. Jelly works well in both batch and real-time settings – including files, sockets, or streaming protocols like Kafka or gRPC.
 
 **pyjelly** is a Python implementation of the Jelly protocol. It provides:
 
@@ -12,36 +14,25 @@
 
 ## Overview
 
-### Use cases
-
-pyjelly is suitable for:
-
-* Compact serialization of large RDF graphs and datasets.
-* Incremental or streaming processing of RDF data.
-* Writing or reading `.jelly` files in data pipelines.
-* Efficient on-disk storage of RDF collections.
-* Interchange of RDF data between systems.
-
 ### Supported stream types
 
-pyjelly supports all [*physical* stream types]({{ proto_link("specification/reference/#physicalstreamtype") }}) including `TRIPLES`, `QUADS` and `GRAPHS`.
+pyjelly supports all [physical stream types]({{ proto_link("specification/reference/#physicalstreamtype") }}): `TRIPLES`, `QUADS` and `GRAPHS`.
 
 See the full [stream type matrix]({{ proto_link("serialization/#consistency-with-physical-stream-types") }}) for an overview of valid combinations.
 
-### Conformance to the Jelly protocol
+### Conformance to the Jelly specification
 
-pyjelly is designed to conform to [version {{ proto_version() }} of the Jelly specification]({{ proto_link("specification/") }}). It adheres to:
+pyjelly is continuously tested for conformance to [the Jelly specification]({{ proto_link("specification/") }}). While the vast majority of features are implemented, there are a few edge cases left to resolve.
 
-* Stream header structure and metadata.
-* Frame structure and ordering guarantees.
-* Compression rules and lookup tables.
-* Namespace declarations and stream options.
+You can track the progress in [the conformance test suite definition]({{ git_link("tests/utils/rdf_test_cases.py") }}).
 
-Parsing includes automatic validation of conformance raised when violations occur.
+## Use cases
 
-### Limitations
+Use cases for pyjelly include:
 
-* Grouped logical stream types are not yet supported.
-* Quoted graphs (RDF-star nested triples) are not supported.
-* Multi-dataset streams cannot currently be parsed into a single `Dataset`.
-* Logical stream type detection is not automatic; it must be set explicitly via options.
+- **Client-server communication** – link your client app in Python to the server (e.g., [Apache Jena, RDF4J](https://w3id.org/jelly/jelly-jvm)) with Jelly to reduce latency and improve user experience.
+- **Inter-service communication** – use Jelly to efficiently exchange RDF data between microservices.
+- **Data science workflows** – use Jelly to read and write RDF data in data science pipelines, enabling efficient processing of large datasets. 
+    - pyjelly is fully streaming, so it can handle large datasets without loading everything into memory at once.
+    - We are working on support for pandas and other data science libraries – stay tuned for updates!
+- **Database dumps and bulk loads** – quickly read and write large RDF datasets with Jelly, reducing storage space and improving database maintenance tasks.


### PR DESCRIPTION
There was a lot of outdated or incorrect info. I've restructured it to be easier to read, clearer, and more useful in general.

I've also fixed the git_link macro, because it was b0rked.