### PR TITLE
Add default values for graph/dataset lambdas

### DIFF
--- a/pyjelly/integrations/rdflib/parse.py
+++ b/pyjelly/integrations/rdflib/parse.py
@@ -311,8 +311,8 @@ def parse_quads_stream(
 
 def parse_jelly_grouped(
     inp: IO[bytes],
-    graph_factory: Callable[[], Graph],
-    dataset_factory: Callable[[], Dataset],
+    graph_factory: Callable[[], Graph] = lambda: Graph(),
+    dataset_factory: Callable[[], Dataset] = lambda: Dataset(),
 ) -> Generator[Graph] | Generator[Dataset]:
     """
     Take jelly file and return generators based on the detected logical type.
@@ -321,8 +321,10 @@ def parse_jelly_grouped(
 
     Args:
         inp (IO[bytes]): input jelly buffered binary stream
-        graph_factory (Callable): lambda to construct a Graph
-        dataset_factory (Callable): lambda to construct a Dataset
+        graph_factory (Callable): lambda to construct a Graph.
+            By default creates empty in-memory Graph, but you can pass something else here.
+        dataset_factory (Callable): lambda to construct a Dataset.
+            By default creates empty in-memory Dataset, but you can pass something else here.
 
     Raises:
         NotImplementedError: is raised if a logical type is not implemented
@@ -374,8 +376,8 @@ def parse_jelly_grouped(
 
 def parse_jelly_to_graph(
     inp: IO[bytes],
-    graph_factory: Callable[[], Graph],
-    dataset_factory: Callable[[], Dataset],
+    graph_factory: Callable[[], Graph] = lambda: Graph(),
+    dataset_factory: Callable[[], Dataset] = lambda: Dataset(),
 ) -> Graph | Dataset:
     """
     Add statements from Generator to provided Graph/Dataset.
@@ -383,7 +385,9 @@ def parse_jelly_to_graph(
     Args:
         inp (IO[bytes]): input jelly stream.
         graph_factory (Callable[[], Graph]): factory to create Graph.
+            By default creates empty in-memory Graph, but you can pass something else here.
         dataset_factory (Callable[[], Dataset]): factory to create Dataset.
+            By default creates empty in-memory Dataset, but you can pass something else here.
 
     Returns:
         Dataset | Graph: Dataset or Graph with statements.


### PR DESCRIPTION
This will make calling these these parsing methods less annoying, at least for the common case of in-memory graphs/datasets.