### PR TITLE
Fix tests with multiple input files in serialization

### DIFF
--- a/tests/conformance_tests/test_rdf/test_serialize.py
+++ b/tests/conformance_tests/test_rdf/test_serialize.py
@@ -36,10 +36,12 @@ def test_serializes(path: Path) -> None:
         options=options_filename,
         out_filename=actual_out,
     )
-    for input_filename in input_filenames:
+    for frame_no, input_filename in enumerate(input_filenames):
         jelly_validate(
             actual_out,
             "--compare-ordered",
+            "--compare-frame-indices",
+            frame_no,
             "--compare-to-rdf-file",
             input_filename,
             "--options-file",

--- a/tests/utils/ordered_memory.py
+++ b/tests/utils/ordered_memory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator, Iterator
+from itertools import groupby
 from typing import Any
 from typing_extensions import TypeAlias
 
@@ -54,7 +55,13 @@ class OrderedMemory(Store):
 
     def contexts(self, triple: Triple | None = None) -> Generator[Graph]:
         if triple is None:
-            yield from self._seen_contexts.values()
+            for ctx, statements in groupby(self._quads, key=lambda x: x[1]):
+                if ctx is not None:
+                    new_store = self.__class__()
+                    graph = Graph(store=new_store, identifier=ctx.identifier)
+                    for statement, _ in statements:
+                        graph.add(statement)
+                    yield graph
         else:
             seen_ids = set()
             for t, ctx in self._quads:

--- a/tests/utils/rdf_test_cases.py
+++ b/tests/utils/rdf_test_cases.py
@@ -12,29 +12,11 @@ import pytest
 # TODO(Piotr): Remove this list once the failing test cases are fixed.
 # See https://github.com/Jelly-RDF/pyjelly/issues/145
 failing_test_cases = [
-    "from_jelly_graphs_pos_002",
-    "from_jelly_quads_pos_004",
-    "from_jelly_quads_pos_005",
-    "from_jelly_quads_pos_007",
     "from_jelly_triples_pos_014",
     "from_jelly_triples_pos_015",
     "from_jelly_triples_pos_017",
     "from_jelly_triples_pos_018",
-    "to_jelly_graphs_pos_001",
-    "to_jelly_graphs_pos_002",
-    "to_jelly_graphs_pos_003",
-    "to_jelly_graphs_pos_004",
-    "to_jelly_graphs_pos_005",
-    "to_jelly_graphs_pos_006",
-    "to_jelly_graphs_pos_007",
-    "to_jelly_graphs_pos_008",
-    "to_jelly_graphs_pos_009",
-    "to_jelly_quads_pos_004",
-    "to_jelly_quads_pos_005",
-    "to_jelly_quads_pos_006",
-    "to_jelly_triples_pos_011",
     "to_jelly_triples_pos_014",
-    "to_jelly_triples_pos_016",
 ]
 
 JELLY_CLI = shutil.which("jelly-cli")


### PR DESCRIPTION
Closes #207 

Needs https://github.com/Jelly-RDF/pyjelly/pull/206 first.

Changes:
- as conformance tests provide one file per frame, made the serialization in tests serialize each input file to a separate frame
- jelly rdf validate was not comparing per frame, fixed that too
- that fixed ~10 conformance tests