### PR TITLE
Added empty frames handling during parsing

### DIFF
--- a/tests/utils/rdf_test_cases.py
+++ b/tests/utils/rdf_test_cases.py
@@ -12,10 +12,6 @@ import pytest
 # TODO(Piotr): Remove this list once the failing test cases are fixed.
 # See https://github.com/Jelly-RDF/pyjelly/issues/145
 failing_test_cases = [
-    "from_jelly_triples_pos_014",
-    "from_jelly_triples_pos_015",
-    "from_jelly_triples_pos_017",
-    "from_jelly_triples_pos_018",
     "to_jelly_triples_pos_014",
 ]
 


### PR DESCRIPTION
Closes #205 

Changes:
- when parsing Jelly file, ALL frames are returned (even if they have no rows)
- options are read from the first non-empty frame
- fixed 4 conformance tests