### PR TITLE
Add user story for writinga flat Jelly file with iterators

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -62,6 +62,24 @@ If you have a generator object containing graphs, you can easily serialize it in
 This method allows for transmitting logically grouped data, preserving their original division.
 For more precise control over frame serialization you can use [lower-level API](api.md)
 
+### Serializing a stream of statements
+
+If you have a generator object containing statements, you can easily serialize it into the Jelly format, like in the following example: 
+
+{{ code_example('rdflib/07_serialize_flat.py')}}
+
+This flat mode transmits each statement in order and then adds a final marker, keeping the simplicity and order of the data.
+For more precise control over frame serialization you can use [lower-level API](api.md)
+
+### Serializing a stream of graphs
+
+If you have a generator object containing graphs, you can easily serialize it into the Jelly format, like in the following example: 
+
+{{ code_example('rdflib/06_serialize_grouped.py')}}
+
+This method allows for transmitting logically grouped data, preserving their original division.
+For more precise control over frame serialization you can use [lower-level API](api.md)
+
 ### File extension support
 
 You can generally omit the `format="jelly"` parameter if the file ends in `.jelly` – RDFLib will auto-detect the format:

--- a/examples/rdflib/07_serialize_flat.py
+++ b/examples/rdflib/07_serialize_flat.py
@@ -1,0 +1,19 @@
+from pyjelly.integrations.rdflib.serialize import flat_stream_to_file
+from rdflib import Literal, Namespace
+import random
+
+
+# example generator with triplet statements
+def generate_sample_triples():
+    ex = Namespace("http://example.org/")
+    for _ in range(10):
+        yield (ex.sensor, ex.temperature, Literal(random.random()))
+
+
+output_file_name = "flat_output.jelly"
+
+print(f"Streaming triples into {output_file_name}…")
+sample_triples = generate_sample_triples()
+with open(output_file_name, "wb") as out_file:
+    flat_stream_to_file(sample_triples, out_file)
+print("All done.")


### PR DESCRIPTION
- add a Python script with a user story, which writes example data stream into a Jelly format
- generalise the behaviour of stream functions to also include statements
- added note/information in the getting-started.md file