### PR TITLE
Added generic parser

### DIFF
--- a/pyjelly/integrations/generic/generic_sink.py
+++ b/pyjelly/integrations/generic/generic_sink.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import re
+from collections import deque
+from collections.abc import Generator, Iterable
+from pathlib import Path
+from typing import Union
+from typing_extensions import Self
+
+Node = Union[str, "Triple"]
+check_if_iri = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
+
+
+class Triple(tuple[Node, Node, Node]):
+    __slots__ = ()
+
+    def __new__(cls, s: Node, p: Node, o: Node) -> Self:
+        return tuple.__new__(cls, (s, p, o))
+
+    @property
+    def s(self) -> Node:
+        return self[0]
+
+    @property
+    def p(self) -> Node:
+        return self[1]
+
+    @property
+    def o(self) -> Node:
+        return self[2]
+
+
+class Quad(tuple[Node, Node, Node, Node]):
+    __slots__ = ()
+
+    def __new__(cls, s: Node, p: Node, o: Node, g: Node) -> Self:
+        return tuple.__new__(cls, (s, p, o, g))
+
+    @property
+    def s(self) -> Node:
+        return self[0]
+
+    @property
+    def p(self) -> Node:
+        return self[1]
+
+    @property
+    def o(self) -> Node:
+        return self[2]
+
+    @property
+    def g(self) -> Node:
+        return self[3]
+
+
+class GenericStatementSink:
+    _store: deque[tuple[Node, ...]]
+
+    def __init__(self) -> None:
+        self._store: deque[tuple[Node, ...]] = deque()
+        self._namespaces: dict[Node, Node] = {}
+
+    def add(self, statement: Iterable[Node]) -> None:
+        self._store.append(tuple(statement))
+
+    def bind(self, prefix: str, namespace: str) -> None:
+        self._namespaces.update({prefix: namespace})
+
+    def __iter__(self) -> Generator[tuple[Node, ...]]:
+        yield from self._store
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+    @property
+    def is_triples_sink(self) -> bool:
+        triples_arity = 3
+        return len(self._store[0]) == triples_arity
+
+    def _nt_token(self, node: Node) -> str:
+        if isinstance(node, str) and node.startswith("_:"):
+            return node
+        if isinstance(node, Triple):
+            quoted_triple = [self._nt_token(t) for t in node]
+            return "<< " + " ".join(quoted_triple) + " >>"
+        if isinstance(node, str) and bool(check_if_iri.match(node)):
+            return f"<{node}>"
+        return node
+
+    def serialize(self, output_filename: Path, encoding: str) -> None:
+        with output_filename.open("w", encoding=encoding) as output_file:
+            for statement in self._store:
+                output_file.write(
+                    " ".join(self._nt_token(t) for t in statement) + " .\n"
+                )

--- a/pyjelly/integrations/generic/generic_sink.py
+++ b/pyjelly/integrations/generic/generic_sink.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from collections import deque
 from collections.abc import Generator, Iterable
 from pathlib import Path
-from typing import Union
-from typing_extensions import Self
+from typing import NamedTuple, Union
 
 
 class BlankNode:
@@ -54,87 +53,28 @@ class Literal:
 Node = Union[BlankNode, IRI, Literal, "Triple", str]
 
 
-class Triple(tuple[Node, Node, Node]):
-    """
-    Class for RDF triples.
+class Triple(NamedTuple):
+    """Class for RDF triples."""
 
-    Args:
-        tuple (Node): tuple of three elements (s/p/o),
-        being of one of the types of Node.
-
-    """
-
-    __slots__ = ()
-
-    def __new__(cls, s: Node, p: Node, o: Node) -> Self:
-        return tuple.__new__(cls, (s, p, o))
-
-    @property
-    def s(self) -> Node:
-        return self[0]
-
-    @property
-    def p(self) -> Node:
-        return self[1]
-
-    @property
-    def o(self) -> Node:
-        return self[2]
+    s: Node
+    p: Node
+    o: Node
 
 
-class Quad(tuple[Node, Node, Node, Node]):
-    """
-    Class for RDF quads.
+class Quad(NamedTuple):
+    """Class for RDF quads."""
 
-    Args:
-        tuple (Node): tuple of four elements (s/p/o/g),
-        being of one of the types of Node.
-
-    """
-
-    __slots__ = ()
-
-    def __new__(cls, s: Node, p: Node, o: Node, g: Node) -> Self:
-        return tuple.__new__(cls, (s, p, o, g))
-
-    @property
-    def s(self) -> Node:
-        return self[0]
-
-    @property
-    def p(self) -> Node:
-        return self[1]
-
-    @property
-    def o(self) -> Node:
-        return self[2]
-
-    @property
-    def g(self) -> Node:
-        return self[3]
+    s: Node
+    p: Node
+    o: Node
+    g: Node
 
 
-class Prefix(tuple[str, IRI]):
-    """
-    Class for generic namespace declaration.
+class Prefix(NamedTuple):
+    """Class for generic namespace declaration."""
 
-    Args:
-        tuple (str, IRI): namespace prefix and URI.
-
-    """
-
-    __slots__ = ()
-
-    def __new__(cls, prefix: str, iri: IRI) -> Self:
-        return tuple.__new__(cls, (prefix, iri))
-
-    @property
-    def prefix(self) -> str:
-        return self[0]
-
-    @property
-    def iri(self) -> IRI:
-        return self[1]
+    prefix: str
+    iri: IRI
 
 
 class GenericStatementSink:

--- a/pyjelly/integrations/generic/generic_sink.py
+++ b/pyjelly/integrations/generic/generic_sink.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
-import re
 from collections import deque
 from collections.abc import Generator, Iterable
 from pathlib import Path
 from typing import Union
 from typing_extensions import Self
 
-check_if_iri = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
-
 
 class BlankNode:
+    """Class for blank nodes, storing BN's identifier as a string."""
+
     def __init__(self, identifier: str) -> None:
         self._identifier: str = identifier
 
@@ -19,6 +18,8 @@ class BlankNode:
 
 
 class IRI:
+    """Class for IRIs, storing IRI as a string."""
+
     def __init__(self, iri: str) -> None:
         self._iri: str = iri
 
@@ -27,6 +28,15 @@ class IRI:
 
 
 class Literal:
+    """
+    Class for literals.
+
+    Notes:
+        Consists of: lexical form, and optional language tag and datatype.
+        All parts of literal are stored as strings.
+
+    """
+
     def __init__(self, lex: str, langtag: str | None, datatype: str | None) -> None:
         self._lex: str = lex
         self._langtag: str | None = langtag
@@ -45,6 +55,15 @@ Node = Union[BlankNode, IRI, Literal, "Triple", str]
 
 
 class Triple(tuple[Node, Node, Node]):
+    """
+    Class for RDF triples.
+
+    Args:
+        tuple (Node): tuple of three elements (s/p/o),
+        being of one of the types of Node.
+
+    """
+
     __slots__ = ()
 
     def __new__(cls, s: Node, p: Node, o: Node) -> Self:
@@ -64,6 +83,15 @@ class Triple(tuple[Node, Node, Node]):
 
 
 class Quad(tuple[Node, Node, Node, Node]):
+    """
+    Class for RDF quads.
+
+    Args:
+        tuple (Node): tuple of four elements (s/p/o/g),
+        being of one of the types of Node.
+
+    """
+
     __slots__ = ()
 
     def __new__(cls, s: Node, p: Node, o: Node, g: Node) -> Self:
@@ -86,10 +114,40 @@ class Quad(tuple[Node, Node, Node, Node]):
         return self[3]
 
 
+class Prefix(tuple[str, IRI]):
+    """
+    Class for generic namespace declaration.
+
+    Args:
+        tuple (str, IRI): namespace prefix and URI.
+
+    """
+
+    __slots__ = ()
+
+    def __new__(cls, prefix: str, iri: IRI) -> Self:
+        return tuple.__new__(cls, (prefix, iri))
+
+    @property
+    def prefix(self) -> str:
+        return self[0]
+
+    @property
+    def iri(self) -> IRI:
+        return self[1]
+
+
 class GenericStatementSink:
     _store: deque[tuple[Node, ...]]
 
     def __init__(self) -> None:
+        """
+        Initialize statements storage and namespaces dictionary.
+
+        Notes:
+            _store preserves the order of statements.
+
+        """
         self._store: deque[tuple[Node, ...]] = deque()
         self._namespaces: dict[str, IRI] = {}
 
@@ -102,23 +160,49 @@ class GenericStatementSink:
     def __iter__(self) -> Generator[tuple[Node, ...]]:
         yield from self._store
 
-    def __len__(self) -> int:
-        return len(self._store)
+    @property
+    def namespaces(self) -> Generator[tuple[str, IRI]]:
+        yield from self._namespaces.items()
 
     @property
     def is_triples_sink(self) -> bool:
+        """
+        Check if the sink contains triples or quads.
+
+        Returns:
+            bool: true, if length of statement is 3.
+
+        """
         triples_arity = 3
         return len(self._store[0]) == triples_arity
 
-    def _nt_token(self, node: Node) -> str:
+    def _serialize_node(self, node: Node) -> str:
+        """
+        Serialize node to its string representation.
+
+        Args:
+            node (Node): Node to convert - RDF term, str, or Triple.
+
+        Returns:
+            str: string representation of Node.
+
+        """
         if isinstance(node, Triple):
-            quoted_triple = [self._nt_token(t) for t in node]
+            quoted_triple = [self._serialize_node(t) for t in node]
             return "<< " + " ".join(quoted_triple) + " >>"
         return str(node)
 
-    def serialize(self, output_filename: Path, encoding: str) -> None:
+    def serialize(self, output_filename: Path, encoding: str = "utf-8") -> None:
+        """
+        Serialize sink's store content to a simple N-triples/N-quads format.
+
+        Args:
+            output_filename (Path): path to the output file.
+            encoding (str): encoding of output. Defaults to utf-8.
+
+        """
         with output_filename.open("w", encoding=encoding) as output_file:
             for statement in self._store:
                 output_file.write(
-                    " ".join(self._nt_token(t) for t in statement) + " .\n"
+                    " ".join(self._serialize_node(t) for t in statement) + " .\n"
                 )

--- a/pyjelly/integrations/generic/parse.py
+++ b/pyjelly/integrations/generic/parse.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from collections.abc import Generator, Iterable
+from itertools import chain
+from typing import IO, Any, Callable, Union
+from typing_extensions import Self, override
+
+from pyjelly import jelly
+from pyjelly.errors import JellyConformanceError
+from pyjelly.integrations.generic.generic_sink import GenericStatementSink, Quad, Triple
+from pyjelly.parse.decode import Adapter, Decoder, ParserOptions
+from pyjelly.parse.ioutils import get_options_and_frames
+
+Statement = Union[Triple, Quad]
+
+
+class Prefix(tuple[str, str]):
+    __slots__ = ()
+
+    def __new__(cls, prefix: str, iri: str) -> Self:
+        return tuple.__new__(cls, (prefix, iri))
+
+    @property
+    def prefix(self) -> str:
+        return self[0]
+
+    @property
+    def iri(self) -> str:
+        return self[1]
+
+
+class GenericStatementSinkAdapter(Adapter):
+    """
+    Implement Adapter for generic statements.
+
+    Args:
+        Adapter (_type_): base Adapter class
+
+    """
+
+    @override
+    def iri(self, iri: str) -> str:
+        return iri
+
+    @override
+    def bnode(self, bnode: str) -> str:
+        return "_:" + bnode
+
+    @override
+    def default_graph(self) -> str:
+        return ""
+
+    @override
+    def literal(
+        self,
+        lex: str,
+        language: str | None = None,
+        datatype: str | None = None,
+    ) -> str:
+        suffix = ""
+        if language:
+            suffix = f"@{language}"
+        elif datatype:
+            suffix = f"^^<{datatype}>"
+        return f'"{lex}"{suffix}'
+
+    @override
+    def namespace_declaration(self, name: str, iri: str) -> Prefix:
+        return Prefix(name, self.iri(iri))
+
+
+class GenericTriplesAdapter(GenericStatementSinkAdapter):
+    def __init__(
+        self,
+        options: ParserOptions,
+    ) -> None:
+        super().__init__(options=options)
+
+    @override
+    def triple(self, terms: Iterable[Any]) -> Triple:
+        return Triple(*terms)
+
+
+class RDFLibQuadsBaseAdapter(GenericStatementSinkAdapter):
+    def __init__(self, options: ParserOptions) -> None:
+        super().__init__(options=options)
+
+
+class GenericQuadsAdapter(RDFLibQuadsBaseAdapter):
+    @override
+    def quad(self, terms: Iterable[Any]) -> Quad:
+        return Quad(*terms)
+
+    @override
+    def triple(self, terms: Iterable[Any]) -> Triple:
+        return Triple(*terms)
+
+
+class GenericGraphsAdapter(RDFLibQuadsBaseAdapter):
+    _graph_id: str | None
+
+    def __init__(
+        self,
+        options: ParserOptions,
+    ) -> None:
+        super().__init__(options=options)
+        self._graph_id = None
+
+    @property
+    def graph(self) -> None:
+        if self._graph_id is None:
+            msg = "new graph was not started"
+            raise JellyConformanceError(msg)
+
+    @override
+    def graph_start(self, graph_id: str) -> None:
+        self._graph_id = graph_id
+
+    @override
+    def triple(self, terms: Iterable[Any]) -> Quad:
+        return Quad(*chain(terms, [self._graph_id]))
+
+    @override
+    def graph_end(self) -> None:
+        self._graph_id = None
+
+
+def parse_triples_stream(
+    frames: Iterable[jelly.RdfStreamFrame],
+    options: ParserOptions,
+) -> Generator[Iterable[Triple | Prefix]]:
+    """
+    Parse flat triple stream.
+
+    Args:
+        frames (Iterable[jelly.RdfStreamFrame]): iterator over stream frames
+        options (ParserOptions): stream options
+
+    Yields:
+        Generator[Iterable[Triple | Prefix]]:
+            Generator of iterables of Triple or Prefix objects,
+            one iterable per frame.
+
+    """
+    adapter = GenericTriplesAdapter(options)
+    decoder = Decoder(adapter=adapter)
+    for frame in frames:
+        yield decoder.iter_rows(frame)
+    return
+
+
+def parse_quads_stream(
+    frames: Iterable[jelly.RdfStreamFrame],
+    options: ParserOptions,
+) -> Generator[Iterable[Quad | Prefix]]:
+    """
+    Parse flat quads stream.
+
+    Args:
+        frames (Iterable[jelly.RdfStreamFrame]): iterator over stream frames
+        options (ParserOptions): stream options
+
+    Yields:
+        Generator[Iterable[Quad | Prefix]]:
+            Generator of iterables of Quad or Prefix objects,
+            one iterable per frame.
+
+    """
+    adapter_class: type[RDFLibQuadsBaseAdapter]
+    if options.stream_types.physical_type == jelly.PHYSICAL_STREAM_TYPE_QUADS:
+        adapter_class = GenericQuadsAdapter
+    else:
+        adapter_class = GenericGraphsAdapter
+    adapter = adapter_class(options=options)
+    decoder = Decoder(adapter=adapter)
+    for frame in frames:
+        yield decoder.iter_rows(frame)
+    return
+
+
+def parse_jelly_grouped(
+    inp: IO[bytes],
+    sink_factory: Callable[[], GenericStatementSink] = lambda: GenericStatementSink(),
+) -> Generator[GenericStatementSink]:
+    options, frames = get_options_and_frames(inp)
+    if options.stream_types.physical_type == jelly.PHYSICAL_STREAM_TYPE_TRIPLES:
+        for graph in parse_triples_stream(
+            frames=frames,
+            options=options,
+        ):
+            sink = sink_factory()
+            for graph_item in graph:
+                if isinstance(graph_item, Prefix):
+                    sink.bind(graph_item.prefix, graph_item.iri)
+                else:
+                    sink.add(graph_item)
+            yield sink
+        return
+    elif options.stream_types.physical_type in (
+        jelly.PHYSICAL_STREAM_TYPE_QUADS,
+        jelly.PHYSICAL_STREAM_TYPE_GRAPHS,
+    ):
+        for dataset in parse_quads_stream(
+            frames=frames,
+            options=options,
+        ):
+            sink = sink_factory()
+            for item in dataset:
+                if isinstance(item, Prefix):
+                    sink.bind(item.prefix, item.iri)
+                else:
+                    sink.add(item)
+            yield sink
+        return
+
+    physical_type_name = jelly.PhysicalStreamType.Name(
+        options.stream_types.physical_type
+    )
+    msg = f"the stream type {physical_type_name} is not supported "
+    raise NotImplementedError(msg)
+
+
+def parse_jelly_to_graph(
+    inp: IO[bytes],
+    sink_factory: Callable[[], GenericStatementSink] = lambda: GenericStatementSink(),
+) -> GenericStatementSink:
+    options, frames = get_options_and_frames(inp)
+    sink = sink_factory()
+
+    for item in parse_jelly_flat(inp=inp, frames=frames, options=options):
+        if isinstance(item, Prefix):
+            sink.bind(item.prefix, item.iri)
+        else:
+            sink.add(item)
+    return sink
+
+
+def parse_jelly_flat(
+    inp: IO[bytes],
+    frames: Iterable[jelly.RdfStreamFrame] | None = None,
+    options: ParserOptions | None = None,
+) -> Generator[Statement | Prefix]:
+    if not frames or not options:
+        options, frames = get_options_and_frames(inp)
+
+    if options.stream_types.physical_type == jelly.PHYSICAL_STREAM_TYPE_TRIPLES:
+        for triples in parse_triples_stream(frames=frames, options=options):
+            yield from triples
+        return
+    if options.stream_types.physical_type in (
+        jelly.PHYSICAL_STREAM_TYPE_QUADS,
+        jelly.PHYSICAL_STREAM_TYPE_GRAPHS,
+    ):
+        for quads in parse_quads_stream(
+            frames=frames,
+            options=options,
+        ):
+            yield from quads
+        return
+    physical_type_name = jelly.PhysicalStreamType.Name(
+        options.stream_types.physical_type
+    )
+    msg = f"the stream type {physical_type_name} is not supported "
+    raise NotImplementedError(msg)

--- a/pyjelly/integrations/generic/parse.py
+++ b/pyjelly/integrations/generic/parse.py
@@ -7,17 +7,24 @@ from typing_extensions import Self, override
 
 from pyjelly import jelly
 from pyjelly.errors import JellyConformanceError
-from pyjelly.integrations.generic.generic_sink import GenericStatementSink, Quad, Triple
+from pyjelly.integrations.generic.generic_sink import (
+    IRI,
+    BlankNode,
+    GenericStatementSink,
+    Literal,
+    Quad,
+    Triple,
+)
 from pyjelly.parse.decode import Adapter, Decoder, ParserOptions
 from pyjelly.parse.ioutils import get_options_and_frames
 
 Statement = Union[Triple, Quad]
 
 
-class Prefix(tuple[str, str]):
+class Prefix(tuple[str, IRI]):
     __slots__ = ()
 
-    def __new__(cls, prefix: str, iri: str) -> Self:
+    def __new__(cls, prefix: str, iri: IRI) -> Self:
         return tuple.__new__(cls, (prefix, iri))
 
     @property
@@ -25,7 +32,7 @@ class Prefix(tuple[str, str]):
         return self[0]
 
     @property
-    def iri(self) -> str:
+    def iri(self) -> IRI:
         return self[1]
 
 
@@ -39,12 +46,12 @@ class GenericStatementSinkAdapter(Adapter):
     """
 
     @override
-    def iri(self, iri: str) -> str:
-        return iri
+    def iri(self, iri: str) -> IRI:
+        return IRI(iri)
 
     @override
-    def bnode(self, bnode: str) -> str:
-        return "_:" + bnode
+    def bnode(self, bnode: str) -> BlankNode:
+        return BlankNode(bnode)
 
     @override
     def default_graph(self) -> str:
@@ -56,13 +63,8 @@ class GenericStatementSinkAdapter(Adapter):
         lex: str,
         language: str | None = None,
         datatype: str | None = None,
-    ) -> str:
-        suffix = ""
-        if language:
-            suffix = f"@{language}"
-        elif datatype:
-            suffix = f"^^<{datatype}>"
-        return f'"{lex}"{suffix}'
+    ) -> Literal:
+        return Literal(lex, language, datatype)
 
     @override
     def namespace_declaration(self, name: str, iri: str) -> Prefix:

--- a/pyjelly/integrations/rdflib/parse.py
+++ b/pyjelly/integrations/rdflib/parse.py
@@ -315,7 +315,7 @@ def parse_jelly_grouped(
     dataset_factory: Callable[[], Dataset] = lambda: Dataset(),
 ) -> Generator[Graph] | Generator[Dataset]:
     """
-    Take jelly file and return generators based on the detected logical type.
+    Take jelly file and return generators based on the detected physical type.
 
     Yields one graph/dataset per frame.
 
@@ -329,7 +329,7 @@ def parse_jelly_grouped(
             but you can pass something else here.
 
     Raises:
-        NotImplementedError: is raised if a logical type is not implemented
+        NotImplementedError: is raised if a physical type is not implemented
 
     Yields:
         Generator[Graph] | Generator[Dataset]:
@@ -426,7 +426,7 @@ def parse_jelly_flat(
     options: ParserOptions | None = None,
 ) -> Generator[Statement | Prefix]:
     """
-    Parse jelly file with FLAT physical type into a Generator of stream events.
+    Parse jelly file with FLAT logical type into a Generator of stream events.
 
     Args:
         inp (IO[bytes]): input jelly buffered binary stream.

--- a/pyjelly/parse/decode.py
+++ b/pyjelly/parse/decode.py
@@ -405,4 +405,5 @@ class Decoder:
         str: decode_bnode,
         jelly.RdfLiteral: decode_literal,
         jelly.RdfDefaultGraph: decode_default_graph,
+        jelly.RdfTriple: decode_triple,
     }

--- a/tests/conformance_tests/test_rdf/test_parse.py
+++ b/tests/conformance_tests/test_rdf/test_parse.py
@@ -20,6 +20,8 @@ from tests.utils.ordered_memory import OrderedMemory
 from tests.utils.rdf_test_cases import (
     GeneralizedTestCasesDir,
     PhysicalTypeTestCasesDir,
+    RDFStarGeneralizedTestCasesDir,
+    RDFStarTestCasesDir,
     id_from_path,
     jelly_validate,
     needs_jelly_cli,
@@ -91,6 +93,33 @@ def test_parses(path: Path) -> None:
     glob="pos_*",
 )
 def test_generalized_parses(path: Path) -> None:
+    run_generic_test(path)
+
+
+@needs_jelly_cli
+@walk_directories(
+    RDF_FROM_JELLY_TESTS_DIR / RDFStarTestCasesDir.TRIPLES,
+    RDF_FROM_JELLY_TESTS_DIR / RDFStarTestCasesDir.QUADS,
+    RDF_FROM_JELLY_TESTS_DIR / RDFStarTestCasesDir.GRAPHS,
+    glob="pos_*",
+)
+def test_rdf_star_parses(path: Path) -> None:
+    run_generic_test(path)
+
+
+@needs_jelly_cli
+@walk_directories(
+    RDF_FROM_JELLY_TESTS_DIR / RDFStarGeneralizedTestCasesDir.TRIPLES,
+    RDF_FROM_JELLY_TESTS_DIR / RDFStarGeneralizedTestCasesDir.QUADS,
+    RDF_FROM_JELLY_TESTS_DIR / RDFStarGeneralizedTestCasesDir.GRAPHS,
+    glob="pos_*",
+)
+def test_rdf_star_generalized_parses(path: Path) -> None:
+    run_generic_test(path)
+
+
+@needs_jelly_cli
+def run_generic_test(path: Path) -> None:
     input_filename = path / "in.jelly"
     test_id = id_from_path(path)
     output_dir = TEST_OUTPUTS_DIR / test_id
@@ -126,3 +155,39 @@ def test_parsing_fails(path: Path) -> None:
     dataset = Dataset(store=OrderedMemory())
     with pytest.raises(Exception):  # TODO: more specific  # noqa: PT011, B017, TD002
         dataset.parse(location=input_filename, format="jelly")
+
+
+@needs_jelly_cli
+def run_generic_fail_test(path: Path) -> None:
+    input_filename = path / "in.jelly"
+    test_id = id_from_path(path)
+    output_dir = TEST_OUTPUTS_DIR / test_id
+    output_dir.mkdir(exist_ok=True)
+
+    with (
+        pytest.raises(Exception),  # TODO: more specific  # noqa: PT011, B017, TD002
+        input_filename.open("rb") as input_file,
+    ):
+        list(generic_parse_jelly_grouped(input_file))
+
+
+@needs_jelly_cli
+@walk_directories(
+    RDF_FROM_JELLY_TESTS_DIR / RDFStarTestCasesDir.TRIPLES,
+    RDF_FROM_JELLY_TESTS_DIR / RDFStarTestCasesDir.GRAPHS,
+    RDF_FROM_JELLY_TESTS_DIR / RDFStarTestCasesDir.QUADS,
+    glob="neg_*",
+)
+def test_parsing_rdf_star_fails(path: Path) -> None:
+    run_generic_fail_test(path)
+
+
+@needs_jelly_cli
+@walk_directories(
+    RDF_FROM_JELLY_TESTS_DIR / RDFStarGeneralizedTestCasesDir.TRIPLES,
+    RDF_FROM_JELLY_TESTS_DIR / RDFStarGeneralizedTestCasesDir.GRAPHS,
+    RDF_FROM_JELLY_TESTS_DIR / RDFStarGeneralizedTestCasesDir.QUADS,
+    glob="neg_*",
+)
+def test_parsing_rdf_star_generalized_fails(path: Path) -> None:
+    run_generic_fail_test(path)

--- a/tests/conformance_tests/test_rdf/test_parse.py
+++ b/tests/conformance_tests/test_rdf/test_parse.py
@@ -8,6 +8,9 @@ from rdflib import Dataset, Graph, Literal, Node
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
 from rdflib.plugins.serializers.nt import _quoteLiteral
 
+from pyjelly.integrations.generic.parse import (
+    parse_jelly_grouped as generic_parse_jelly_grouped,
+)
 from pyjelly.integrations.rdflib.parse import parse_jelly_grouped
 from tests.meta import (
     RDF_FROM_JELLY_TESTS_DIR,
@@ -15,6 +18,7 @@ from tests.meta import (
 )
 from tests.utils.ordered_memory import OrderedMemory
 from tests.utils.rdf_test_cases import (
+    GeneralizedTestCasesDir,
     PhysicalTypeTestCasesDir,
     id_from_path,
     jelly_validate,
@@ -68,6 +72,34 @@ def test_parses(path: Path) -> None:
             graph.serialize(
                 destination=output_filename, encoding="utf-8", format=extension
             )
+            jelly_validate(
+                input_filename,
+                "--compare-ordered",
+                "--compare-frame-indices",
+                frame_no,
+                "--compare-to-rdf-file",
+                output_filename,
+                hint=f"Test ID: {test_id}, output file: {output_filename}",
+            )
+
+
+@needs_jelly_cli
+@walk_directories(
+    RDF_FROM_JELLY_TESTS_DIR / GeneralizedTestCasesDir.TRIPLES,
+    RDF_FROM_JELLY_TESTS_DIR / GeneralizedTestCasesDir.QUADS,
+    RDF_FROM_JELLY_TESTS_DIR / GeneralizedTestCasesDir.GRAPHS,
+    glob="pos_*",
+)
+def test_generalized_parses(path: Path) -> None:
+    input_filename = path / "in.jelly"
+    test_id = id_from_path(path)
+    output_dir = TEST_OUTPUTS_DIR / test_id
+    output_dir.mkdir(exist_ok=True)
+    with input_filename.open("rb") as input_file:
+        for frame_no, graph in enumerate(generic_parse_jelly_grouped(input_file)):
+            extension = f"n{'triples' if graph.is_triples_sink else 'quads'}"
+            output_filename = output_dir / f"out_{frame_no:03}.{extension[:2]}"
+            graph.serialize(output_filename=output_filename, encoding="utf-8")
             jelly_validate(
                 input_filename,
                 "--compare-ordered",

--- a/tests/utils/rdf_test_cases.py
+++ b/tests/utils/rdf_test_cases.py
@@ -57,6 +57,24 @@ class PhysicalTypeTestCasesDir(str, Enum):
         return self.value
 
 
+class GeneralizedTestCasesDir(str, Enum):
+    TRIPLES = "triples_rdf_1_1_generalized"
+    QUADS = "quads_rdf_1_1_generalized"
+    GRAPHS = "graphs_rdf_1_1_generalized"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class RDFStarTestCasesDir(str, Enum):
+    TRIPLES = "triples_rdf_star"
+    QUADS = "quads_rdf_star"
+    GRAPHS = "graphs_rdf_star"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 def walk_directories(
     *dirs: str | Path,
     glob: str | None = None,

--- a/tests/utils/rdf_test_cases.py
+++ b/tests/utils/rdf_test_cases.py
@@ -66,6 +66,15 @@ class GeneralizedTestCasesDir(str, Enum):
         return self.value
 
 
+class RDFStarGeneralizedTestCasesDir(str, Enum):
+    TRIPLES = "triples_rdf_star_generalized"
+    QUADS = "quads_rdf_star_generalized"
+    GRAPHS = "graphs_rdf_star_generalized"
+
+    def __str__(self) -> str:
+        return self.value
+
+
 class RDFStarTestCasesDir(str, Enum):
     TRIPLES = "triples_rdf_star"
     QUADS = "quads_rdf_star"


### PR DESCRIPTION
Relates to #213 

Changes:
- (re)introduced GenericStatementSink that just takes statements and can serialize them to N-triples or N-quads
- added an Adapter that returns s/p/o/g as strings
- added helper functions with the same logic as in RDFLib integration, but they use GenericStatementSink as a base and return GenericStatemenrSink, Generator[GenericStatementSink], or Generator[Statement | Prefix]
- introduced generalized RDF conformance tests for parsing (and they pass, apparently)