### PR TITLE
Refactored generic statement sink and added a simple parser

### DIFF
--- a/pyjelly/integrations/generic/generic_sink.py
+++ b/pyjelly/integrations/generic/generic_sink.py
@@ -41,7 +41,9 @@ class Literal:
 
     """
 
-    def __init__(self, lex: str, langtag: str | None, datatype: str | None) -> None:
+    def __init__(
+        self, lex: str, langtag: str | None = None, datatype: str | None = None
+    ) -> None:
         self._lex: str = lex
         self._langtag: str | None = langtag
         self._datatype: str | None = datatype
@@ -86,9 +88,9 @@ class Prefix(NamedTuple):
 
 
 class GenericStatementSink:
-    _store: deque[tuple[Node, ...]]
+    _store: deque[Triple | Quad]
 
-    def __init__(self) -> None:
+    def __init__(self, identifier: str | None = None) -> None:
         """
         Initialize statements storage, namespaces dictionary, and parser/serializer.
 
@@ -96,22 +98,31 @@ class GenericStatementSink:
             _store preserves the order of statements.
 
         """
-        self._store: deque[tuple[Node, ...]] = deque()
+        self._store: deque[Triple | Quad] = deque()
         self._namespaces: dict[str, IRI] = {}
         self._parser: GenericSinkParser = GenericSinkParser()
+        self._identifier = identifier if identifier else DEFAULT_GRAPH_IDENTIFIER
 
-    def add(self, statement: Iterable[Node]) -> None:
-        self._store.append(tuple(statement))
+    def add(self, statement: Triple | Quad) -> None:
+        self._store.append(statement)
 
     def bind(self, prefix: str, namespace: IRI) -> None:
         self._namespaces.update({prefix: namespace})
 
-    def __iter__(self) -> Generator[tuple[Node, ...]]:
+    def __iter__(self) -> Generator[Triple | Quad]:
         yield from self._store
 
     @property
     def namespaces(self) -> Generator[tuple[str, IRI]]:
         yield from self._namespaces.items()
+
+    @property
+    def identifier(self) -> str:
+        return self._identifier
+
+    @property
+    def store(self) -> Generator[Triple | Quad]:
+        yield from self._store
 
     @property
     def is_triples_sink(self) -> bool:

--- a/pyjelly/integrations/generic/generic_sink.py
+++ b/pyjelly/integrations/generic/generic_sink.py
@@ -262,7 +262,7 @@ class GenericSinkParser:
         match_quoted_triple = self._quoted_triple_re.match(term)
         if match_quoted_triple:
             quoted_triple = self._token_quoted_triple_re.search(term)
-            if quoted_triple and len(quoted_triple.groups()) == TRIPLE_ARITY:
+            if quoted_triple:
                 triple_tokens = self.generate_statement_tokens(
                     quoted_triple.groups()[0]
                 )

--- a/pyjelly/integrations/generic/generic_sink.py
+++ b/pyjelly/integrations/generic/generic_sink.py
@@ -214,7 +214,7 @@ class GenericSinkParser:
     _uri_re = re.compile(r"<([^>\s]+)>")  # returns URI
     _bn_re = re.compile(r"_:(\S+)")  # returns blank node identificator
     _literal_re = re.compile(
-        r""""([^"]*)"(?:@(\S+)|\^\^(\S+))?"""
+        r""""([^"]*)"(?:@(\S+)|\^\^<(\S+)>)?"""
     )  # returns lex part of the literal and optional langtag and datatype
     _quoted_triple_re = re.compile(
         r"<<.*?>>"
@@ -266,13 +266,11 @@ class GenericSinkParser:
             return IRI(match_iri.groups()[0])
         match_literal = self._literal_re.match(term)
         if match_literal:
-            max_literal_group_number = 2
-            literal_parts = match_literal.groups()
-            if literal_parts[0]:  # has lex part of the literal
-                return Literal(*literal_parts)
-            if len(literal_parts) > max_literal_group_number:
+            lex, langtag, datatype = match_literal.groups()
+            if not lex or (langtag is not None and datatype is not None):
                 msg = "invalid literal encountered"
                 raise TypeError(msg)
+            return Literal(lex, langtag, datatype)
 
         match_quoted_triple = self._quoted_triple_re.match(term)
         if match_quoted_triple:

--- a/pyjelly/integrations/generic/generic_sink.py
+++ b/pyjelly/integrations/generic/generic_sink.py
@@ -63,7 +63,10 @@ class Literal:
         return f'"{self._lex}"{suffix}'
 
     def __repr__(self) -> str:
-        return f"Literal({self._lex!r}, langtag={self._langtag!r}, datatype={self._datatype!r})"
+        return (
+            f"Literal({self._lex!r}, langtag={self._langtag!r}, "
+            f"datatype={self._datatype!r})"
+        )
 
 
 Node = Union[BlankNode, IRI, Literal, "Triple", str]

--- a/pyjelly/integrations/generic/generic_sink.py
+++ b/pyjelly/integrations/generic/generic_sink.py
@@ -194,7 +194,11 @@ class GenericStatementSink:
 
         """
         warnings.warn(
-            "This is a minimal parser for the NT/NQ format, not intended for use outside of conformance tests. Proceed with caution.",
+            (
+                "This is a minimal parser for the NT/NQ format, "
+                "not intended for use outside of conformance tests. "
+                "Proceed with caution."
+            ),
             category=UserWarning,
             stacklevel=2,
         )

--- a/pyjelly/integrations/generic/generic_sink.py
+++ b/pyjelly/integrations/generic/generic_sink.py
@@ -194,7 +194,7 @@ class GenericStatementSink:
 
         """
         warnings.warn(
-            "this is a minimal parser from NT/NQ format, proceed with caution",
+            "This is a minimal parser for the NT/NQ format, not intended for use outside of conformance tests. Proceed with caution.",
             category=UserWarning,
             stacklevel=2,
         )

--- a/pyjelly/integrations/generic/generic_sink.py
+++ b/pyjelly/integrations/generic/generic_sink.py
@@ -17,8 +17,11 @@ class BlankNode:
     def __init__(self, identifier: str) -> None:
         self._identifier: str = identifier
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         return f"_:{self._identifier}"
+
+    def __repr__(self) -> str:
+        return f"BlankNode(identifier={self._identifier})"
 
 
 class IRI:
@@ -27,8 +30,11 @@ class IRI:
     def __init__(self, iri: str) -> None:
         self._iri: str = iri
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         return f"<{self._iri}>"
+
+    def __repr__(self) -> str:
+        return f"IRI({self._iri})"
 
 
 class Literal:
@@ -48,13 +54,16 @@ class Literal:
         self._langtag: str | None = langtag
         self._datatype: str | None = datatype
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         suffix = ""
         if self._langtag:
             suffix = f"@{self._langtag}"
         elif self._datatype:
             suffix = f"^^<{self._datatype}>"
         return f'"{self._lex}"{suffix}'
+
+    def __repr__(self) -> str:
+        return f"Literal({self._lex!r}, langtag={self._langtag!r}, datatype={self._datatype!r})"
 
 
 Node = Union[BlankNode, IRI, Literal, "Triple", str]
@@ -90,7 +99,7 @@ class Prefix(NamedTuple):
 class GenericStatementSink:
     _store: deque[Triple | Quad]
 
-    def __init__(self, identifier: str = DEFAULT_GRAPH_IDENTIFIER) -> None:
+    def __init__(self, identifier: Node = DEFAULT_GRAPH_IDENTIFIER) -> None:
         """
         Initialize statements storage, namespaces dictionary, and parser.
 
@@ -116,12 +125,15 @@ class GenericStatementSink:
     def __iter__(self) -> Generator[Triple | Quad]:
         yield from self._store
 
+    def __len__(self) -> int:
+        return len(self._store)
+
     @property
     def namespaces(self) -> Generator[tuple[str, IRI]]:
         yield from self._namespaces.items()
 
     @property
-    def identifier(self) -> str:
+    def identifier(self) -> Node:
         return self._identifier
 
     @property
@@ -199,7 +211,7 @@ class GenericSinkParser:
     _uri_re = re.compile(r"<([^>\s]+)>")  # returns URI
     _bn_re = re.compile(r"_:(\S+)")  # returns blank node identificator
     _literal_re = re.compile(
-        r"""("[^"]*")(?:@(\S+)|\^\^(\S+))?"""
+        r""""([^"]*)"(?:@(\S+)|\^\^(\S+))?"""
     )  # returns lex part of the literal and optional langtag and datatype
     _quoted_triple_re = re.compile(
         r"<<.*?>>"

--- a/pyjelly/serialize/encode.py
+++ b/pyjelly/serialize/encode.py
@@ -32,8 +32,10 @@ def split_iri(iri_string: str) -> tuple[str, str]:
 
 T = TypeVar("T")
 RowsAnd: TypeAlias = tuple[Sequence[jelly.RdfStreamRow], T]
-RowsAndTerm: TypeAlias = "RowsAnd[jelly.RdfIri | jelly.RdfLiteral | str | \
+RowsAndTerm: TypeAlias = (
+    "RowsAnd[jelly.RdfIri | jelly.RdfLiteral | str | \
     jelly.RdfDefaultGraph | jelly.RdfTriple]"
+)
 
 
 class TermEncoder:

--- a/pyjelly/serialize/encode.py
+++ b/pyjelly/serialize/encode.py
@@ -32,10 +32,8 @@ def split_iri(iri_string: str) -> tuple[str, str]:
 
 T = TypeVar("T")
 RowsAnd: TypeAlias = tuple[Sequence[jelly.RdfStreamRow], T]
-RowsAndTerm: TypeAlias = (
-    "RowsAnd[jelly.RdfIri | jelly.RdfLiteral | str | \
+RowsAndTerm: TypeAlias = "RowsAnd[jelly.RdfIri | jelly.RdfLiteral | str | \
     jelly.RdfDefaultGraph | jelly.RdfTriple]"
-)
 
 
 class TermEncoder:


### PR DESCRIPTION
Related to #218 

Needs https://github.com/Jelly-RDF/pyjelly/pull/219 first.

Added a simple parser that works for .nt and .nq files, including quoted triples. No validation of statements is done (the warning is in place to notify anyone who uses the parser), only simple matching to identify parts of statements/namespace declarations.