### PR TITLE
Example 04: limit output to 50 graphs

### DIFF
--- a/examples/rdflib/04_parse_grouped.py
+++ b/examples/rdflib/04_parse_grouped.py
@@ -16,5 +16,5 @@ with (
     for i, graph in enumerate(graphs):
         print(f"Graph {i} in the stream has {len(graph)} triples")
         # Limit to 50 graphs for demonstration -- the rest will not be parsed
-        if i >= 100:
+        if i >= 50:
             break


### PR DESCRIPTION
Printing the entire thing to console is... tedious and confusing. Better limit it to first N graphs, so that the example runs faster, is easier to read, and also to showcase early stopping capability.