### PR TITLE
CI: capture output of tested code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,11 @@ jobs:
       if: ${{ !cancelled() && steps.install.conclusion == 'success' && matrix.conformance-tests }}
 
     - name: Run unit tests
-      run: uv run pytest -svv
+      run: uv run pytest -vv
       if: ${{ !cancelled() && steps.install.conclusion == 'success' && !matrix.conformance-tests }}
 
     - name: Run unit tests (with conformance tests and coverage)
-      run: uv run pytest -svv --cov --cov-branch --cov-report=xml
+      run: uv run pytest -vv --cov --cov-branch --cov-report=xml
       if: ${{ !cancelled() && steps.install.conclusion == 'success' && matrix.conformance-tests }}
 
     - name: Upload coverage reports to Codecov


### PR DESCRIPTION
The examples that we have in tests can output quite a lot of stuff to stdout, which can make the CI logs hard to read.

Remove the -s option to capture this output.