### PR TITLE
Exclude examples from test coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
 ignore:
   - "docs"
   - "tests"
+  - "examples"


### PR DESCRIPTION
We can't reliably test them 100% anyway... and they are not part of the library, so it doesn't make sense to measure the coverage for them.