### PR TITLE
Move pytest-cov out of runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ keywords = ["RDF", "Knowledge graph", "Jelly", "Serialization format"]
 license = "Apache-2.0"
 dependencies = [
     "protobuf>=6.30.0",
-    "pytest-cov>=6.2.1",
     "typing-extensions>=4.12.2", # revisit after 3.13 is older
 ]
 
@@ -65,6 +64,7 @@ test = [
     "hypothesis>=6.131.0",
     "inline-snapshot>=0.20.8",
     "pytest>=8.3.4",
+    "pytest-cov>=6.2.1",
     "pytest-accept>=0.1.12",
     "pytest-mock>=3.14.0",
     "pytest-subtests>=0.14.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1377,7 +1377,6 @@ version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "protobuf" },
-    { name = "pytest-cov" },
     { name = "typing-extensions" },
 ]
 
@@ -1418,6 +1417,7 @@ test = [
     { name = "inline-snapshot" },
     { name = "pytest" },
     { name = "pytest-accept" },
+    { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-subtests" },
     { name = "pytest-sugar" },
@@ -1429,7 +1429,6 @@ types = [
 [package.metadata]
 requires-dist = [
     { name = "protobuf", specifier = ">=6.30.0" },
-    { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "rdflib", marker = "extra == 'rdflib'", specifier = ">=7.1.4" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
 ]
@@ -1463,6 +1462,7 @@ test = [
     { name = "inline-snapshot", specifier = ">=0.20.8" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-accept", specifier = ">=0.1.12" },
+    { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
     { name = "pytest-subtests", specifier = ">=0.14.1" },
     { name = "pytest-sugar", specifier = ">=1.0.0" },


### PR DESCRIPTION
Relates to #247.
Self-explanatory within the title.  
Thanks @bswck for the great point in the issue!