### PR TITLE
Remove identifier from generic examples.

### DIFF
--- a/examples/generic/01_serialize.py
+++ b/examples/generic/01_serialize.py
@@ -1,7 +1,7 @@
 from pyjelly.integrations.generic.generic_sink import *
 
-# Create a generic sink object, identifier is optional
-generic_sink = GenericStatementSink(identifier="my_graph")
+# Create a generic sink object
+generic_sink = GenericStatementSink()
 
 # Let's add triples one by one
 generic_sink.add(

--- a/examples/generic/02_parse.py
+++ b/examples/generic/02_parse.py
@@ -1,7 +1,7 @@
 from pyjelly.integrations.generic.generic_sink import *
 
-# Create a generic sink object, identifier is optional
-generic_sink = GenericStatementSink(identifier="my_graph")
+# Create a generic sink object
+generic_sink = GenericStatementSink()
 
 # Load triples from the Jelly file
 with open("output.jelly", "rb") as in_file:

--- a/examples/generic/04_serialize_grouped.py
+++ b/examples/generic/04_serialize_grouped.py
@@ -10,8 +10,8 @@ def generate_sample_sinks():
         IRI("http://example.com/humidity"),
         IRI(f"http://example.com/{random.random()}"),
     )
-    for i in range(10):
-        sink = GenericStatementSink(identifier=f"graph_{i}")
+    for _ in range(10):
+        sink = GenericStatementSink()
         sink.add(Triple(*content))
         yield sink
 


### PR DESCRIPTION
Remove unnecessary `identifier` argument from the GenericStatementSink object in examples.