### PR TITLE
Add small fix for test parser

### DIFF
--- a/tests/integration_tests/test_sink_generic/test_parser.py
+++ b/tests/integration_tests/test_sink_generic/test_parser.py
@@ -1,0 +1,82 @@
+import pytest
+
+from pyjelly.integrations.generic.generic_sink import (
+    Literal,
+    Triple,
+    GenericStatementSink,
+)
+from tests.utils.generic_sink_test_parser import GenericSinkParser
+
+
+@pytest.mark.parametrize(
+    (
+        "lex",
+        "langtag",
+        "datatype",
+        "expected_str",
+    ),
+    [
+        ("hello", None, None, '"hello"'),
+        ("", None, None, '""'),
+        ("123", None, None, '"123"'),
+        ("true", None, None, '"true"'),
+        ("hello", "en", None, '"hello"@en'),
+        ("bonjour", "fr", None, '"bonjour"@fr'),
+        ("hallo", "de", None, '"hallo"@de'),
+        ("hello", "en-US", None, '"hello"@en-US'),
+        ("café", "fr", None, '"café"@fr'),
+        (
+            "123",
+            None,
+            "http://www.w3.org/2001/XMLSchema#integer",
+            '"123"^^<http://www.w3.org/2001/XMLSchema#integer>',
+        ),
+        (
+            "3.14",
+            None,
+            "http://www.w3.org/2001/XMLSchema#float",
+            '"3.14"^^<http://www.w3.org/2001/XMLSchema#float>',
+        ),
+        (
+            "true",
+            None,
+            "http://www.w3.org/2001/XMLSchema#boolean",
+            '"true"^^<http://www.w3.org/2001/XMLSchema#boolean>',
+        ),
+        (
+            "2023-01-01",
+            None,
+            "http://www.w3.org/2001/XMLSchema#date",
+            '"2023-01-01"^^<http://www.w3.org/2001/XMLSchema#date>',
+        ),
+        (
+            "hello",
+            None,
+            "http://www.w3.org/2001/XMLSchema#string",
+            '"hello"^^<http://www.w3.org/2001/XMLSchema#string>',
+        ),
+        ("line1\nline2", None, None, '"line1\nline2"'),
+        ("tab\there", None, None, '"tab\there"'),
+        ("backslash\\here", None, None, '"backslash\\here"'),
+        ("résumé", "fr", None, '"résumé"@fr'),
+        ("München", "de", None, '"München"@de'),
+        ("日本語", "ja", None, '"日本語"@ja'),
+        ("🚀", None, None, '"🚀"'),
+        (" ", None, None, '" "'),
+        ("  whitespace  ", None, None, '"  whitespace  "'),
+        ("", "en", None, '""@en'),
+        (
+            "",
+            None,
+            "http://www.w3.org/2001/XMLSchema#string",
+            '""^^<http://www.w3.org/2001/XMLSchema#string>',
+        ),
+    ],
+)
+def test_literal_str(lex: str, langtag: str, datatype: str, expected_str: str) -> None:
+    """Test literals parsing."""
+    literal = str(Literal(lex, langtag, datatype))
+    test_statement = f"_:bn <http://www.examples.org/predicate> {literal} ."
+    gp = GenericSinkParser(GenericStatementSink())
+    triple = gp.parse_statement(test_statement, Triple)
+    assert str(triple[2]) == expected_str

--- a/tests/unit_tests/test_parse/test_nt_parser.py
+++ b/tests/unit_tests/test_parse/test_nt_parser.py
@@ -1,9 +1,9 @@
 import pytest
 
 from pyjelly.integrations.generic.generic_sink import (
+    GenericStatementSink,
     Literal,
     Triple,
-    GenericStatementSink,
 )
 from tests.utils.generic_sink_test_parser import GenericSinkParser
 
@@ -73,7 +73,9 @@ from tests.utils.generic_sink_test_parser import GenericSinkParser
         ),
     ],
 )
-def test_literal_str(lex: str, langtag: str, datatype: str, expected_str: str) -> None:
+def test_literal_parsing(
+    lex: str, langtag: str, datatype: str, expected_str: str
+) -> None:
     """Test literals parsing."""
     literal = str(Literal(lex, langtag, datatype))
     test_statement = f"_:bn <http://www.examples.org/predicate> {literal} ."

--- a/tests/utils/generic_sink_test_parser.py
+++ b/tests/utils/generic_sink_test_parser.py
@@ -35,7 +35,7 @@ class GenericSinkParser:
     _split_tokens = re.compile(  # matches str to quoted triple/literal, IRI, or BN
         r"""
         <<.+?>>         |
-        "[^"]+"(?:@\S+|\^\^\S+)?  |
+        "[^"]*"(?:@\S+|\^\^\S+)?  |
         <[^>]+>         |
         _:\S+           |
         """,
@@ -77,7 +77,7 @@ class GenericSinkParser:
         match_literal = self._literal_re.match(term)
         if match_literal:
             lex, langtag, datatype = match_literal.groups()
-            if not lex or (langtag is not None and datatype is not None):
+            if langtag is not None and datatype is not None:
                 msg = "invalid literal encountered"
                 raise TypeError(msg)
             return Literal(lex, langtag, datatype)


### PR DESCRIPTION
In the test parser, literals like "" were causing trouble. Fixed the regex that parses literals and added a simple test to check if various types of literals are parsed correctly. 