### PR TITLE
Change default graph representation in generic statement sink

### DIFF
--- a/pyjelly/integrations/generic/generic_sink.py
+++ b/pyjelly/integrations/generic/generic_sink.py
@@ -4,7 +4,15 @@ from collections import deque
 from collections.abc import Generator
 from typing import IO, NamedTuple, Union
 
-DEFAULT_GRAPH_IDENTIFIER = ""
+
+class _DefaultGraph:
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return ""
+
+
+DefaultGraph = _DefaultGraph()
 
 
 class BlankNode:
@@ -93,7 +101,8 @@ class Literal:
         return hash((self._lex, self._langtag, self._datatype))
 
 
-Node = Union[BlankNode, IRI, Literal, "Triple", str]
+Node = Union[BlankNode, IRI, Literal, "Triple"]
+GraphName = Union[Node, _DefaultGraph]
 
 
 TRIPLE_ARITY = 3
@@ -113,7 +122,7 @@ class Quad(NamedTuple):
     s: Node
     p: Node
     o: Node
-    g: Node
+    g: GraphName
 
 
 class Prefix(NamedTuple):
@@ -126,7 +135,7 @@ class Prefix(NamedTuple):
 class GenericStatementSink:
     _store: deque[Triple | Quad]
 
-    def __init__(self, identifier: Node = DEFAULT_GRAPH_IDENTIFIER) -> None:
+    def __init__(self, identifier: GraphName = DefaultGraph) -> None:
         """
         Initialize statements storage, namespaces dictionary, and parser.
 
@@ -135,7 +144,7 @@ class GenericStatementSink:
 
         Args:
             identifier (str, optional): Identifier for a sink.
-                Defaults to DEFAULT_GRAPH_IDENTIFIER.
+                Defaults to DefaultGraph.
 
         """
         self._store: deque[Triple | Quad] = deque()
@@ -159,7 +168,7 @@ class GenericStatementSink:
         yield from self._namespaces.items()
 
     @property
-    def identifier(self) -> Node:
+    def identifier(self) -> GraphName:
         return self._identifier
 
     @property

--- a/pyjelly/integrations/generic/generic_sink.py
+++ b/pyjelly/integrations/generic/generic_sink.py
@@ -6,8 +6,6 @@ from typing import IO, NamedTuple, Union
 
 
 class _DefaultGraph:
-    __slots__ = ()
-
     def __repr__(self) -> str:
         return ""
 

--- a/pyjelly/integrations/generic/parse.py
+++ b/pyjelly/integrations/generic/parse.py
@@ -10,9 +10,10 @@ from pyjelly.errors import JellyConformanceError
 from pyjelly.integrations.generic.generic_sink import (
     IRI,
     BlankNode,
+    DefaultGraph,
     GenericStatementSink,
+    GraphName,
     Literal,
-    Node,
     Prefix,
     Quad,
     Triple,
@@ -45,8 +46,8 @@ class GenericStatementSinkAdapter(Adapter):
         return BlankNode(bnode)
 
     @override
-    def default_graph(self) -> str:
-        return ""
+    def default_graph(self) -> GraphName:
+        return DefaultGraph
 
     @override
     def literal(
@@ -123,7 +124,7 @@ class GenericGraphsAdapter(GenericQuadsBaseAdapter):
 
     """
 
-    _graph_id: Node | None
+    _graph_id: GraphName | None
 
     def __init__(
         self,
@@ -139,7 +140,7 @@ class GenericGraphsAdapter(GenericQuadsBaseAdapter):
             raise JellyConformanceError(msg)
 
     @override
-    def graph_start(self, graph_id: Node) -> None:
+    def graph_start(self, graph_id: GraphName) -> None:
         self._graph_id = graph_id
 
     @override

--- a/pyjelly/integrations/generic/serialize.py
+++ b/pyjelly/integrations/generic/serialize.py
@@ -10,11 +10,11 @@ from pyjelly.integrations.generic.generic_sink import (
     GenericStatementSink,
     Quad,
     Triple,
-    DEFAULT_GRAPH_IDENTIFIER,
+    DefaultGraph,
+    GraphName,
     IRI,
     BlankNode,
     Literal,
-    Node,
 )
 
 from pyjelly import jelly
@@ -44,7 +44,7 @@ class GenericSinkTermEncoder(TermEncoder):
             RowsAndTerm: encoded extra rows and a jelly term to encode
 
         """
-        if slot is Slot.graph and term == DEFAULT_GRAPH_IDENTIFIER:
+        if slot is Slot.graph and term == DefaultGraph:
             return self.encode_default_graph()
 
         if isinstance(term, IRI):
@@ -211,7 +211,7 @@ def split_to_graphs(data: Generator[Quad]) -> Generator[GenericStatementSink]:
         each having triples in store and identifier set.
 
     """
-    current_g: Node | None = None
+    current_g: GraphName | None = None
     current_sink: GenericStatementSink | None = None
     for statement in data:
         if current_g != statement.g:

--- a/tests/integration_tests/test_generic/test_logical_types.py
+++ b/tests/integration_tests/test_generic/test_logical_types.py
@@ -10,8 +10,8 @@ import pytest
 from pyjelly import jelly
 from pyjelly.errors import JellyConformanceError
 from pyjelly.integrations.generic.generic_sink import (
-    DEFAULT_GRAPH_IDENTIFIER,
     IRI,
+    DefaultGraph,
     GenericStatementSink,
     Literal,
     Quad,
@@ -57,7 +57,7 @@ def _make_flat_quads_bytes() -> bytes:
     graph = IRI("http://example.org/graph")
 
     sink.add(Quad(subject, predicate, object1, graph))
-    sink.add(Quad(subject, predicate, object1, DEFAULT_GRAPH_IDENTIFIER))
+    sink.add(Quad(subject, predicate, object1, DefaultGraph))
 
     output = io.BytesIO()
     flat_stream_to_file(sink.store, output)

--- a/tests/integration_tests/test_sink_generic/test_sink.py
+++ b/tests/integration_tests/test_sink_generic/test_sink.py
@@ -14,7 +14,7 @@ from pyjelly.integrations.generic.generic_sink import (
 
 class TestGenericStatementSink(unittest.TestCase):
     def setUp(self) -> None:
-        self.test_obj = GenericStatementSink("graph_id")
+        self.test_obj = GenericStatementSink(IRI("http://example.com/graph_id"))
         self.store_content = (
             IRI("http://example.com/s"),
             IRI("http://example.com/p"),
@@ -29,7 +29,7 @@ class TestGenericStatementSink(unittest.TestCase):
         assert repr(namespaces[0][1]) == repr(IRI("http://example.com/"))
 
     def test_identifier_property(self) -> None:
-        assert self.test_obj.identifier == "graph_id"
+        assert self.test_obj.identifier == IRI("http://example.com/graph_id")
 
     def test_store_property(self) -> None:
         for statement in self.test_obj.store:

--- a/tests/utils/generic_sink_test_serializer.py
+++ b/tests/utils/generic_sink_test_serializer.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from pyjelly.integrations.generic.generic_sink import (
     GenericStatementSink,
+    GraphName,
     Node,
     Triple,
 )
@@ -13,15 +14,15 @@ class GenericSinkSerializer:
     def __init__(self, sink: GenericStatementSink) -> None:
         self._sink = sink
 
-    def _serialize_node(self, node: Node) -> str:
+    def _serialize_node(self, node: Node | GraphName) -> str:
         """
         Serialize node to its string representation.
 
         Args:
-            node (Node): Node to convert - RDF term, str, or Triple.
+            node (Node | GraphName): RDF term, DefaultGraph, or Triple.
 
         Returns:
-            str: string representation of Node.
+            str: string representation of node.
 
         """
         if isinstance(node, Triple):


### PR DESCRIPTION
Previously, the default graph name was simply "", which was not aligned with the RDF specification and could potentially lead to ambiguities. Changed the default graph to a simple class that has "" as a representation and propagated changes to serialization/parsing and tests affected.