### PR TITLE
Move graph name encoding to encode_quad

### DIFF
--- a/pyjelly/serialize/encode.py
+++ b/pyjelly/serialize/encode.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from enum import IntEnum
-from typing import Iterator, TypeVar, Union
+from typing import TypeVar, Union
 from typing_extensions import TypeAlias
 
 from pyjelly import jelly, options


### PR DESCRIPTION
Further split encoding of s/p/o vs g, to remove unnecessary call isinstanc in encode_statement

Changes:
- encode_statement -> encode_spo
- terms in encode_spo are already an iterator 
- encode_graph now is called only within quads context
- updated the docstrings a bit to match the recent changes