### PR TITLE
fix: handle non-seekable input streams in delimited jelly hint

### DIFF
--- a/pyjelly/parse/ioutils.py
+++ b/pyjelly/parse/ioutils.py
@@ -78,11 +78,11 @@ def get_options_and_frames(
             stream types, lookup presets and other stream options
 
     """
-    if not inp.seekable() and isinstance(inp, io.RawIOBase):
+    if not inp.seekable():
         # Input may not be seekable (e.g. a network stream) -- then we need to buffer
         # it to determine if it's delimited.
         # See also: https://github.com/Jelly-RDF/pyjelly/issues/298
-        inp = io.BufferedReader(inp)
+        inp = io.BufferedReader(inp)  # type: ignore[arg-type]
         is_delimited = delimited_jelly_hint(inp.peek(3))
     else:
         is_delimited = delimited_jelly_hint(bytes_read := inp.read(3))

--- a/pyjelly/parse/ioutils.py
+++ b/pyjelly/parse/ioutils.py
@@ -1,3 +1,4 @@
+import io
 import os
 from collections.abc import Generator, Iterator
 from itertools import chain
@@ -48,7 +49,7 @@ def delimited_jelly_hint(header: bytes) -> bool:
     False
     """
     magic = 0x0A
-    return len(header) == 3 and (  # noqa: PLR2004
+    return len(header) >= 3 and (  # noqa: PLR2004
         header[0] != magic or (header[1] == magic and header[2] != magic)
     )
 
@@ -77,8 +78,15 @@ def get_options_and_frames(
             stream types, lookup presets and other stream options
 
     """
-    is_delimited = delimited_jelly_hint(bytes_read := inp.read(3))
-    inp.seek(-len(bytes_read), os.SEEK_CUR)
+    if not inp.seekable() and isinstance(inp, io.RawIOBase):
+        # Input may not be seekable (e.g. a network stream) -- then we need to buffer
+        # it to determine if it's delimited.
+        # See also: https://github.com/Jelly-RDF/pyjelly/issues/298
+        inp = io.BufferedReader(inp)
+        is_delimited = delimited_jelly_hint(inp.peek(3))
+    else:
+        is_delimited = delimited_jelly_hint(bytes_read := inp.read(3))
+        inp.seek(-len(bytes_read), os.SEEK_CUR)
 
     if is_delimited:
         first_frame = None

--- a/tests/unit_tests/test_parse/test_ioutils.py
+++ b/tests/unit_tests/test_parse/test_ioutils.py
@@ -1,0 +1,20 @@
+import io
+
+import pytest
+
+from pyjelly.parse.ioutils import get_options_and_frames
+
+
+# Regression test for https://github.com/Jelly-RDF/pyjelly/issues/298
+def test_get_options_and_frames_no_seek(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Sample data: delimited Jelly file with options
+    data = b"\x11\x0a\x0f\x0a\x0d\x10\x01\x48\x80\x01\x50\x0f\x58\x0f\x70\x01\x78\x01"
+    # Make a bytes IO that does not support seek
+    inp = io.BytesIO(data)
+    monkeypatch.setattr(inp, "seekable", lambda: False)
+
+    def seek() -> None:
+        raise io.UnsupportedOperation
+
+    monkeypatch.setattr(inp, "seek", seek)
+    get_options_and_frames(inp)

--- a/tests/unit_tests/test_parse/test_ioutils.py
+++ b/tests/unit_tests/test_parse/test_ioutils.py
@@ -1,4 +1,5 @@
 import io
+import typing
 
 import pytest
 
@@ -13,7 +14,10 @@ def test_get_options_and_frames_no_seek(monkeypatch: pytest.MonkeyPatch) -> None
     inp = io.BytesIO(data)
     monkeypatch.setattr(inp, "seekable", lambda: False)
 
-    def seek() -> None:
+    def seek(
+        offset: int,  # noqa: ARG001
+        whence: typing.Any,  # noqa: ARG001
+    ) -> None:
         raise io.UnsupportedOperation
 
     monkeypatch.setattr(inp, "seek", seek)


### PR DESCRIPTION
Closes #298

This is not a perfect fix, because BufferedReader will not block on `peek()`, so there are rare edge cases where this will still fail. But, I could not find any other sensible solution and in general there are very, *very* few resources on proper stream handling in Python... so I call that a "good enough".