### PR TITLE
Correct lookup size error message

### DIFF
--- a/pyjelly/parse/lookup.py
+++ b/pyjelly/parse/lookup.py
@@ -26,7 +26,7 @@ class LookupDecoder:
 
     def __init__(self, *, lookup_size: int) -> None:
         if lookup_size > MAX_LOOKUP_SIZE:
-            msg = f"lookup size cannot be bigger than {MAX_LOOKUP_SIZE}"
+            msg = f"lookup size cannot be larger than {MAX_LOOKUP_SIZE}"
             raise JellyAssertionError(msg)
         self.lookup_size = lookup_size
         placeholders = (None,) * lookup_size

--- a/pyjelly/parse/lookup.py
+++ b/pyjelly/parse/lookup.py
@@ -26,7 +26,7 @@ class LookupDecoder:
 
     def __init__(self, *, lookup_size: int) -> None:
         if lookup_size > MAX_LOOKUP_SIZE:
-            msg = f"lookup size must be less than {MAX_LOOKUP_SIZE}"
+            msg = f"lookup size cannot be bigger than {MAX_LOOKUP_SIZE}"
             raise JellyAssertionError(msg)
         self.lookup_size = lookup_size
         placeholders = (None,) * lookup_size

--- a/tests/unit_tests/test_parse/test_lookup_decoder.py
+++ b/tests/unit_tests/test_parse/test_lookup_decoder.py
@@ -16,7 +16,7 @@ def test_lookup_size_ok(size: int) -> None:
 def test_max_lookup_size_exceeded(size: int) -> None:
     with pytest.raises(JellyAssertionError) as excinfo:
         LookupDecoder(lookup_size=size)
-    assert str(excinfo.value) == f"lookup size cannot be bigger than {MAX_LOOKUP_SIZE}"
+    assert str(excinfo.value) == f"lookup size cannot be larger than {MAX_LOOKUP_SIZE}"
 
 
 def test_decode_zero_error() -> None:

--- a/tests/unit_tests/test_parse/test_lookup_decoder.py
+++ b/tests/unit_tests/test_parse/test_lookup_decoder.py
@@ -16,7 +16,7 @@ def test_lookup_size_ok(size: int) -> None:
 def test_max_lookup_size_exceeded(size: int) -> None:
     with pytest.raises(JellyAssertionError) as excinfo:
         LookupDecoder(lookup_size=size)
-    assert str(excinfo.value) == f"lookup size must be less than {MAX_LOOKUP_SIZE}"
+    assert str(excinfo.value) == f"lookup size cannot be bigger than {MAX_LOOKUP_SIZE}"
 
 
 def test_decode_zero_error() -> None:


### PR DESCRIPTION
"must be less than" was incorrect; it can touch the upper bound but can't exceed it.