### PR TITLE
Extend CI to check Python backend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,19 @@ jobs:
       run: uv run pytest -vv
       if: ${{ !cancelled() && steps.install.conclusion == 'success' && !matrix.conformance-tests }}
 
+    - name: Run unit tests (pure Python backend)
+      env:
+        PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
+      run: uv run pytest -vv
+      if: ${{ !cancelled() && steps.install.conclusion == 'success' && !matrix.conformance-tests }}
+
     - name: Run unit tests (with conformance tests and coverage)
+      run: uv run pytest -vv --cov --cov-branch --cov-report=xml
+      if: ${{ !cancelled() && steps.install.conclusion == 'success' && matrix.conformance-tests }}
+
+    - name: Run unit tests (pure Python backend, with conformance tests and coverage)
+      env:
+        PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
       run: uv run pytest -vv --cov --cov-branch --cov-report=xml
       if: ${{ !cancelled() && steps.install.conclusion == 'success' && matrix.conformance-tests }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ defaults:
 jobs:
   check:
     if: ${{ !cancelled() }}
-    name: ${{ matrix.conformance-tests && '(conformance) ' || '' }}${{ matrix.version }} ${{matrix.platform}}
+    name: ${{ matrix.conformance-tests && '(conformance) ' || '' }}${{ matrix.version }} ${{ matrix.platform }} ${{ matrix.backend == 'python' && '(py-backend)' || '' }}
     runs-on: ${{ matrix.platform }}
 
     env:
@@ -36,6 +36,7 @@ jobs:
         conformance-tests: [false]
         version: ['3.9', '3.13']
         platform: [ubuntu-latest, macos-latest, windows-latest]
+        backend: [cpp]
         include:
         - version: '3.10'
           platform: ubuntu-latest
@@ -46,6 +47,10 @@ jobs:
         - version: '3.13'
           platform: ubuntu-latest
           conformance-tests: true
+        - version: '3.13'
+          platform: ubuntu-latest
+          conformance-tests: true
+          backend: python
         # rdflib appears to be broken on 3.14
         # - version: '3.14'
         #   platform: ubuntu-latest
@@ -81,23 +86,15 @@ jobs:
       uses: jelly-rdf/setup-cli@v1
       if: ${{ !cancelled() && steps.install.conclusion == 'success' && matrix.conformance-tests }}
 
+    - name: Select protobuf Python backend
+      if: ${{ matrix.backend == 'python' }}
+      run: echo "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python" >> "$GITHUB_ENV"
+
     - name: Run unit tests
       run: uv run pytest -vv
       if: ${{ !cancelled() && steps.install.conclusion == 'success' && !matrix.conformance-tests }}
 
-    - name: Run unit tests (pure Python backend)
-      env:
-        PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
-      run: uv run pytest -vv
-      if: ${{ !cancelled() && steps.install.conclusion == 'success' && !matrix.conformance-tests }}
-
     - name: Run unit tests (with conformance tests and coverage)
-      run: uv run pytest -vv --cov --cov-branch --cov-report=xml
-      if: ${{ !cancelled() && steps.install.conclusion == 'success' && matrix.conformance-tests }}
-
-    - name: Run unit tests (pure Python backend, with conformance tests and coverage)
-      env:
-        PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION: python
       run: uv run pytest -vv --cov --cov-branch --cov-report=xml
       if: ${{ !cancelled() && steps.install.conclusion == 'success' && matrix.conformance-tests }}
 


### PR DESCRIPTION
The Protobuf Python library has two backends: one in C (which is run by default) and a Python one.
Added CI test for rerunning tests in the Python backend, and to also boost coverage.